### PR TITLE
fix root_group perms issue in group upload

### DIFF
--- a/src/nodejs/lambda-handlers/file-upload.js
+++ b/src/nodejs/lambda-handlers/file-upload.js
@@ -83,12 +83,13 @@ async function getGroupUploadUrlMethod(event, user) {
   const { group_id: groupId } = event;
   const userInfo = await db.user.findById({ id: user });
   const groupIds = userInfo.user_groups.map((group) => group.id);
+  const rootGroupId = '4daa6b22-f015-4ce2-8dac-8b3510004fca';
 
-  if (!userInfo.user_privileges.includes('ADMIN')
+  if (!(userInfo.user_privileges.includes('ADMIN') || groupIds.includes(rootGroupId))
     && !(groupIds.includes(groupId) && userInfo.user_privileges.includes('GROUP_UPLOAD'))) {
     return ({ error: 'Not Authorized' });
   }
-  const groupShortName = userInfo.user_groups.find((group) => group.id === groupId).short_name;
+  const groupShortName = (await db.group.findById({ id: groupId })).short_name;
   const key = prefix ? `group/${groupShortName}/${prefix.replace(/^\/?/, '').replace(/\/?$/, '')}/${fileName}` : `group/${groupShortName}/${fileName}`;
   return generateUploadUrl({
     key,


### PR DESCRIPTION
# Description

Fixes permission error when using group upload as only root group.

## Spec

See Ticket: [EDPUB-1169](https://bugs.earthdata.nasa.gov/browse/EDPUB-1169)

---

## Validation

1. Deploy the branch to sit.
2. Log in with an account that is only in the root_group.
3. Go to the GHRC daac page.
4. Upload a file with the Daac upload too.


---

## Change Log

 Fixes permission error when using group upload as only root group.[ea9cdd225b263f1bc2249c57cff7fec6870a5019](https://github.com/eosdis-nasa/earthdata-pub-api/commit/ea9cdd225b263f1bc2249c57cff7fec6870a5019)