### PR TITLE
added new request permission for daac manager

### DIFF
--- a/src/postgres/7-seed.sql
+++ b/src/postgres/7-seed.sql
@@ -388,6 +388,7 @@ INSERT INTO edprole_privilege VALUES ('a5b4947a-67d2-434e-9889-59c2fad39676', 'W
 INSERT INTO edprole_privilege VALUES ('a5b4947a-67d2-434e-9889-59c2fad39676', 'WORKFLOW_UPDATE');
 
 --RolePrivilege(edprole_id, privilege) DAAC Data Manager
+INSERT INTO edprole_privilege VALUES ('2aa89c57-85f1-4611-812d-b6760bb6295c', 'REQUEST_INITIALIZE');
 INSERT INTO edprole_privilege VALUES ('2aa89c57-85f1-4611-812d-b6760bb6295c', 'REQUEST_DAACREAD');
 INSERT INTO edprole_privilege VALUES ('2aa89c57-85f1-4611-812d-b6760bb6295c', 'REQUEST_LOCK');
 INSERT INTO edprole_privilege VALUES ('2aa89c57-85f1-4611-812d-b6760bb6295c', 'REQUEST_UNLOCK');

--- a/src/postgres/9-updates.sql
+++ b/src/postgres/9-updates.sql
@@ -49,3 +49,6 @@ RAISE;
 --this should not be run until after the db's have been cleaned of duplicate entries as document in the closing of EDPUB-785
 --ALTER TABLE edpuser
 --ADD CONSTRAINT email_unique UNIQUE (email);
+
+--1/3/2014 add in permission for daac data manager to initialize requests
+INSERT INTO edprole_privilege VALUES ('2aa89c57-85f1-4611-812d-b6760bb6295c', 'REQUEST_INITIALIZE');


### PR DESCRIPTION
Allows daac manager role to create submission.
To test log in as just a daac manager and confirm you can create a submission.