### PR TITLE
EDPUB-1180: Add onboard offboard daac endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 <!-- Unreleased changes can be added here. -->
+- Add DAAC onboard/offboard endpoints
 
 ## 1.0.20
 

--- a/src/nodejs/controllers/proxy.js
+++ b/src/nodejs/controllers/proxy.js
@@ -1086,3 +1086,29 @@ module.exports.getFormsAppSubpath = function getFormsAppSubpath(req, res, next) 
     message: 'Placeholder for forms app subpath endpoint.'
   });
 };
+
+module.exports.onboardDaac = function onboardDaac(req, res, next) {
+  const { params } = req.swagger;
+  const { payload } = params;
+  const lambdaEvent = {
+    operation: 'onboardDaac',
+    context: { user_id: req.user_id },
+    ...payload.value
+  };
+  handlers.data(lambdaEvent).then((body) => {
+    setTimeout(() => res.send(body), latency);
+  });
+};
+
+module.exports.offboardDaac = function offboardDaac(req, res, next) {
+  const { params } = req.swagger;
+  const { payload } = params;
+  const lambdaEvent = {
+    operation: 'offboardDaac',
+    context: { user_id: req.user_id },
+    ...payload.value
+  };
+  handlers.data(lambdaEvent).then((body) => {
+    setTimeout(() => res.send(body), latency);
+  });
+};

--- a/src/nodejs/lambda-layers/database-util/src/query/daac.js
+++ b/src/nodejs/lambda-layers/database-util/src/query/daac.js
@@ -6,8 +6,13 @@ const findAll = () => `${find()} ${order()}`;
 const findById = () => `${find()} WHERE daac.id = {{id}} ${order()}`;
 const getIds = (params) => `SELECT id FROM daac WHERE edpgroup_id IN ('${params.group_ids.join("','")}')`;
 const getActiveDaacs = () => `${find()} WHERE hidden = 'false' AND NOT id = '1c36f0b9-b7fd-481b-9cab-3bc3cea35413' ${order()}`;
+const onboard = () => `UPDATE daac SET hidden = FALSE WHERE id = {{id}} RETURNING daac.*`;
+const offboard = () => `UPDATE daac SET hidden = TRUE WHERE id = {{id}} RETURNING daac.*`;
+
 
 module.exports.findAll = findAll;
 module.exports.findById = findById;
 module.exports.getIds = getIds;
 module.exports.getActiveDaacs = getActiveDaacs;
+module.exports.onboard = onboard;
+module.exports.offboard = offboard;

--- a/src/nodejs/lambda-layers/database-util/src/query/parsers.js
+++ b/src/nodejs/lambda-layers/database-util/src/query/parsers.js
@@ -80,3 +80,5 @@ module.exports.getActiveDaacs = many;
 module.exports.getSubmissionDetailsById = one;
 module.exports.getUserCount = one;
 module.exports.getAverageTimeToPublish = many;
+module.exports.onboard = one;
+module.exports.offboard = one;

--- a/src/openapi/openapi.json
+++ b/src/openapi/openapi.json
@@ -11906,6 +11906,251 @@
         },
         "x-router-controller": "cors"
       }
+    },
+    "/api/data/daac/onboard": {
+      "post": {
+        "tags": [
+          "data"
+        ],
+        "summary": "Onboard a DAAC",
+        "description": "Enables a DAAC selection in EDPub",
+        "operationId": "onboardDaac",
+        "requestBody": {
+          "x-name": "payload",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DAAC"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Methods": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Headers": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Cognito_Authorizer": ["openid"]
+          }
+        ],
+        "x-amazon-apigateway-integration": {
+          "uri": "${data_lambda_arn}",
+          "passthroughBehavior": "when_no_match",
+          "httpMethod": "POST",
+          "type": "aws",
+          "responses": {
+            "default": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+                "method.response.header.Access-Control-Allow-Methods": "'*'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key'"
+              }
+            }
+          }
+        },
+        "x-router-controller": "proxy"
+      },
+      "options": {
+        "tags": [
+          "cors"
+        ],
+        "summary": "CORS",
+        "description": "OPTIONS method for CORS",
+        "operationId": "optionsDataDaac",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Methods": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Headers": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {}
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "type": "mock",
+          "requestTemplates": {
+            "application/json": "#set($req = $input.params()) #set($body = $util.parseJson($input.body)) #set($inputRoot = $input.path('$')) {\"operation\":\"onboardDaac\", #if($body.containsKey('id'))\"id\":\"$body.get('id')\",#end \"context\":{\"user_id\":\"$context.authorizer.claims.sub\", \"user_email\": \"$context.authorizer.claims.email\"}}"
+          },
+          "responses": {
+            "default": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+                "method.response.header.Access-Control-Allow-Methods": "'*'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key'"
+              },
+              "responseTemplates": {
+                "application/json": "{}"
+              }
+            }
+          }
+        },
+        "x-router-controller": "cors"
+      }
+    },
+
+    "/api/data/daac/offboard": {
+      "post": {
+        "tags": [
+          "data"
+        ],
+        "summary": "Offboard a DAAC",
+        "description": "Disables a DAAC selection in EDPub",
+        "operationId": "offboardDaac",
+        "requestBody": {
+          "x-name": "payload",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DAAC"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Methods": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Headers": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Cognito_Authorizer": ["openid"]
+          }
+        ],
+        "x-amazon-apigateway-integration": {
+          "uri": "${data_lambda_arn}",
+          "passthroughBehavior": "when_no_match",
+          "httpMethod": "POST",
+          "type": "aws",
+          "responses": {
+            "default": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+                "method.response.header.Access-Control-Allow-Methods": "'*'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key'"
+              }
+            }
+          }
+        },
+        "x-router-controller": "proxy"
+      },
+      "options": {
+        "tags": [
+          "cors"
+        ],
+        "summary": "CORS",
+        "description": "OPTIONS method for CORS",
+        "operationId": "optionsDataDaac",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Methods": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Headers": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {}
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "type": "mock",
+          "requestTemplates": {
+            "application/json": "#set($req = $input.params()) #set($body = $util.parseJson($input.body)) #set($inputRoot = $input.path('$')) {\"operation\":\"offboardDaac\", #if($body.containsKey('id'))\"id\":\"$body.get('id')\",#end \"context\":{\"user_id\":\"$context.authorizer.claims.sub\", \"user_email\": \"$context.authorizer.claims.email\"}}"
+          },
+          "responses": {
+            "default": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+                "method.response.header.Access-Control-Allow-Methods": "'*'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key'"
+              },
+              "responseTemplates": {
+                "application/json": "{}"
+              }
+            }
+          }
+        },
+        "x-router-controller": "cors"
+      }
     }
   },
   "components": {

--- a/src/openapi/openapi.json
+++ b/src/openapi/openapi.json
@@ -11944,13 +11944,6 @@
                   "type": "string"
                 }
               }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
             }
           }
         },
@@ -11964,6 +11957,9 @@
           "passthroughBehavior": "when_no_match",
           "httpMethod": "POST",
           "type": "aws",
+          "requestTemplates": {
+            "application/json": "#set($req = $input.params()) #set($body = $util.parseJson($input.body)) #set($inputRoot = $input.path('$')) {\"operation\":\"onboardDaac\", #if($body.containsKey('id'))\"id\":\"$body.get('id')\",#end \"context\":{\"user_id\":\"$context.authorizer.claims.sub\", \"user_email\": \"$context.authorizer.claims.email\"}}"
+          },
           "responses": {
             "default": {
               "statusCode": "200",
@@ -12010,7 +12006,7 @@
         "x-amazon-apigateway-integration": {
           "type": "mock",
           "requestTemplates": {
-            "application/json": "#set($req = $input.params()) #set($body = $util.parseJson($input.body)) #set($inputRoot = $input.path('$')) {\"operation\":\"onboardDaac\", #if($body.containsKey('id'))\"id\":\"$body.get('id')\",#end \"context\":{\"user_id\":\"$context.authorizer.claims.sub\", \"user_email\": \"$context.authorizer.claims.email\"}}"
+            "application/json": "{\"statusCode\": 200 }"
           },
           "responses": {
             "default": {
@@ -12029,7 +12025,6 @@
         "x-router-controller": "cors"
       }
     },
-
     "/api/data/daac/offboard": {
       "post": {
         "tags": [
@@ -12067,13 +12062,6 @@
                   "type": "string"
                 }
               }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
             }
           }
         },
@@ -12087,6 +12075,9 @@
           "passthroughBehavior": "when_no_match",
           "httpMethod": "POST",
           "type": "aws",
+          "requestTemplates": {
+            "application/json": "#set($req = $input.params()) #set($body = $util.parseJson($input.body)) #set($inputRoot = $input.path('$')) {\"operation\":\"offboardDaac\", #if($body.containsKey('id'))\"id\":\"$body.get('id')\",#end \"context\":{\"user_id\":\"$context.authorizer.claims.sub\", \"user_email\": \"$context.authorizer.claims.email\"}}"
+          },
           "responses": {
             "default": {
               "statusCode": "200",
@@ -12133,7 +12124,7 @@
         "x-amazon-apigateway-integration": {
           "type": "mock",
           "requestTemplates": {
-            "application/json": "#set($req = $input.params()) #set($body = $util.parseJson($input.body)) #set($inputRoot = $input.path('$')) {\"operation\":\"offboardDaac\", #if($body.containsKey('id'))\"id\":\"$body.get('id')\",#end \"context\":{\"user_id\":\"$context.authorizer.claims.sub\", \"user_email\": \"$context.authorizer.claims.email\"}}"
+            "application/json": "{\"statusCode\": 200 }"
           },
           "responses": {
             "default": {


### PR DESCRIPTION
# Description

Add DAAC onboard/offboard endpoints for cloud metrics

## Spec

See Ticket: https://bugs.earthdata.nasa.gov/browse/EDPUB-1180

---

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Run `npm run clean-modules && npm run build:local` in the API repo.
4. Deploy the EDPub applications using `npm run start-dev` in the overview repo.
5. Start to create a request and verify that the ASF DAAC is **NOT** currently select-able. You don't send to submit, viewing the page is validation enough.
6. Use swagger to test the `/api/data/daac/onboard/` endpoint with the following payload:
```
{"id": "c606afba-725b-4ae4-9557-1fd33260ae12"}
```
7. Start to create a request and verify that the ASF DAAC is now select-able.
8. Use swagger to test the `/api/data/daac/offboard/` endpoint with the following payload:
```
{"id": "c606afba-725b-4ae4-9557-1fd33260ae12"}
```
9.  Start to create a request and verify that the ASF DAAC is **NOT** currently select-able.
10. Turn off the EDPub applications by running `npm run stop-dev` in the overview repo.

---