### PR TITLE
removes redundant code from saveSubmission

### DIFF
--- a/src/nodejs/lambda-handlers/submission.js
+++ b/src/nodejs/lambda-handlers/submission.js
@@ -112,10 +112,6 @@ async function metadataMethod(event, user) {
 async function saveMethod(event, user) {
   const { form_id: formId, daac_id: daacId, data } = event;
   let { id } = event;
-  if (!id) {
-    const submission = await initializeMethod(event, user);
-    id = submission.id;
-  }
   await db.submission.updateFormData({ id, form_id: formId, data: JSON.stringify(data) });
   const status = await db.submission.getState({ id });
   if (daacId && daacId !== status.daac_id) {

--- a/src/nodejs/lambda-handlers/submission.js
+++ b/src/nodejs/lambda-handlers/submission.js
@@ -109,9 +109,9 @@ async function metadataMethod(event, user) {
   return response;
 }
 
-async function saveMethod(event, user) {
+async function saveMethod(event) {
   const { form_id: formId, daac_id: daacId, data } = event;
-  let { id } = event;
+  const { id } = event;
   await db.submission.updateFormData({ id, form_id: formId, data: JSON.stringify(data) });
   const status = await db.submission.getState({ id });
   if (daacId && daacId !== status.daac_id) {

--- a/src/nodejs/lambda-handlers/test/handlers/submission.test.js
+++ b/src/nodejs/lambda-handlers/test/handlers/submission.test.js
@@ -160,33 +160,11 @@ describe('submission', () => {
       step: { name: 'test step' },
       daac_id: 'test daac'
     });
-    db.submission.getState.mockReturnValueOnce({ // no id in initialize
-      id: 'temp state',
-      conversation_id: 'test conversation',
-      workflow_id: 'test workflow'
-    });
-    db.submission.getState.mockReturnValueOnce({ // no id in saveMethod
-      id: 'test submission',
-      conversation_id: 'test conversation',
-      workflow_id: 'test workflow',
-      step: { step_message: 'test message' },
-      daac_id: 'another daac'
-    });
-    db.submission.initialize.mockReturnValue({
-      id: 'test submission'
-    });
     expect(await submission.handler(payloadId)).toEqual({
       id: 'test submission',
       conversation_id: 'test conversation',
       workflow_id: 'test workflow',
       step: { name: 'test step' },
-      daac_id: 'test daac'
-    });
-    expect(await submission.handler(payloadNoId)).toEqual({
-      id: 'test submission',
-      conversation_id: 'test conversation',
-      workflow_id: 'test workflow',
-      step: { step_message: 'test message' },
       daac_id: 'test daac'
     });
   });


### PR DESCRIPTION
# Description

Removes redundant code from the saveMethod

## Spec

See Ticket: [EDPUB-863](https://bugs.earthdata.nasa.gov/browse/EDPUB-863)

---

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally. [required branch](https://github.com/eosdis-nasa/earthdata-pub-forms/tree/EDPUB-863-use-initialize-for-new-submission)
3. Create a new request.
4. Fill out the first form confirming all save options work as expected and submit.

---

## Change Log

Removes redundant code from the saveMethod

* [Add _____](link to commitid)
* [Fix _____](link to commitid)