### PR TITLE
Updated contact information label to full name from first and last name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 <!-- Unreleased changes can be added here. -->
+- Updated contact information label to full name from first and last name
 - Renames improperly named /api/data/submission/{operation} endpoints back to the intended /api/submission/{operation}.
 - Add DAAC onboard/offboard endpoints
 - Creates example group and daac.

--- a/src/postgres/7-seed.sql
+++ b/src/postgres/7-seed.sql
@@ -157,12 +157,12 @@ INSERT INTO section_question VALUES ('933da7a8-4db6-4b7b-b128-d815fe151d29', '38
 
 -- Input(question_id, control_id, list_order, label, type, enums, attributes, required_if, show_if, required))
 
-INSERT INTO input VALUES ('80ac5f52-9ed9-4139-b5f9-7b4cebb6a8e2', 'data_producer_info_name', 0, 'First and Last Name', 'text', '{}', '{}', '[]','[]',  True);
+INSERT INTO input VALUES ('80ac5f52-9ed9-4139-b5f9-7b4cebb6a8e2', 'data_producer_info_name', 0, 'Full Name', 'text', '{}', '{}', '[]','[]',  True);
 INSERT INTO input VALUES ('80ac5f52-9ed9-4139-b5f9-7b4cebb6a8e2', 'data_producer_info_organization', 1, 'Organization', 'text', '{}', '{}', '[]','[]',  True);
 INSERT INTO input VALUES ('80ac5f52-9ed9-4139-b5f9-7b4cebb6a8e2', 'data_producer_info_department', 2, 'Department', 'text', '{}', '{}', '[]','[]',  False);
 INSERT INTO input VALUES ('80ac5f52-9ed9-4139-b5f9-7b4cebb6a8e2', 'data_producer_info_email', 3, 'Email', 'email', '{}', '{}', '[]','[]',  True);
 INSERT INTO input VALUES ('80ac5f52-9ed9-4139-b5f9-7b4cebb6a8e2', 'data_producer_info_orcid', 4, 'ORCID', 'text', '{}', '{}', '[]','[]',  False);
-INSERT INTO input VALUES ('f3e2eab9-6375-4e53-9cc2-3d16f318d333', 'poc_name', 0, 'First and Last Name', 'text', '{}', '{}', '[]','[]',  True);
+INSERT INTO input VALUES ('f3e2eab9-6375-4e53-9cc2-3d16f318d333', 'poc_name', 0, 'Full Name', 'text', '{}', '{}', '[]','[]',  True);
 INSERT INTO input VALUES ('f3e2eab9-6375-4e53-9cc2-3d16f318d333', 'poc_organization', 1, 'Organization', 'text', '{}', '{}', '[]','[]',  True);
 INSERT INTO input VALUES ('f3e2eab9-6375-4e53-9cc2-3d16f318d333', 'poc_department', 2, 'Department', 'text', '{}', '{}', '[]','[]',  False);
 INSERT INTO input VALUES ('f3e2eab9-6375-4e53-9cc2-3d16f318d333', 'poc_email', 3, 'Email', 'email', '{}', '{}', '[]','[]',  True);
@@ -204,7 +204,7 @@ INSERT INTO input VALUES ('4c42796a-8ff1-444e-8fc5-82ccad82e5fb', 'data_delivery
 INSERT INTO input VALUES ('40672516-2220-4edc-8c1b-fd9f7e0b978f', 'data_product_volume_amount', 0, '', 'number', '{}', '{"min": "1"}', '[]','[]',  True);
 INSERT INTO input VALUES ('40672516-2220-4edc-8c1b-fd9f7e0b978f', 'data_product_volume_units', 1, '', 'radio', '["KB","MB","GB","TB","PB"]', '{}', '[]','[]',  True);
 INSERT INTO input VALUES ('53a0faa7-f7d4-4ce9-a9dc-a13cef44e1f3', 'example_file_url', 0, '', 'text', '{}', '{}', '[]','[]',  False);
-INSERT INTO input VALUES ('f3e2eab9-6375-4e53-9cc2-3d16f318d332', 'long_term_support_poc_name', 0, 'First and Last Name', 'text', '{}', '{}', '[]','[]',  True);
+INSERT INTO input VALUES ('f3e2eab9-6375-4e53-9cc2-3d16f318d332', 'long_term_support_poc_name', 0, 'Full Name', 'text', '{}', '{}', '[]','[]',  True);
 INSERT INTO input VALUES ('f3e2eab9-6375-4e53-9cc2-3d16f318d332', 'long_term_support_poc_organization', 1, 'Organization', 'text', '{}', '{}', '[]','[]',  True);
 INSERT INTO input VALUES ('f3e2eab9-6375-4e53-9cc2-3d16f318d332', 'long_term_support_poc_department', 2, 'Department', 'text', '{}', '{}', '[]','[]',  False);
 INSERT INTO input VALUES ('f3e2eab9-6375-4e53-9cc2-3d16f318d332', 'long_term_support_poc_email', 3, 'Email', 'email', '{}', '{}', '[]','[]',  True);

--- a/src/postgres/9-updates.sql
+++ b/src/postgres/9-updates.sql
@@ -92,4 +92,5 @@ INSERT INTO step_edge VALUES ('a5a14d98-df13-47f2-b86b-1504c7d4360d', 'data_publ
 INSERT INTO step_edge VALUES ('a5a14d98-df13-47f2-b86b-1504c7d4360d', 'export_metadata', 'close');
 
 UPDATE daac SET hidden=false, workflow_id='a5a14d98-df13-47f2-b86b-1504c7d4360d' WHERE id='6b3ea184-57c5-4fc5-a91b-e49708f91b67';
+update input SET label='Full Name' WHERE label='First and Last Name';
 

--- a/src/sample-data/json/form-data-submission.json
+++ b/src/sample-data/json/form-data-submission.json
@@ -18,7 +18,7 @@
             {
               "type": "text",
               "control_id": "data_producer_info_name",
-              "label": "First and Last Name",
+              "label": "Full Name",
               "validation_error_msg": "Please enter a name for the point of contact.",
               "required": true
             },
@@ -55,7 +55,7 @@
             {
               "type": "text",
               "control_id": "poc_name",
-              "label": "First and Last Name",
+              "label": "Full Name",
               "validation_error_msg": "Please enter a name for the point of contact.",
               "required": true
             },
@@ -92,7 +92,7 @@
             {
               "type": "text",
               "control_id": "long_term_support_poc_name",
-              "label": "First and Last Name",
+              "label": "Full Name",
               "validation_error_msg": "Please enter a name for the long-term point of contact.",
               "required": true
             },

--- a/src/sample-data/json/form-submission-request.json
+++ b/src/sample-data/json/form-submission-request.json
@@ -18,7 +18,7 @@
             {
               "type": "text",
               "control_id": "data_producer_info_name",
-              "label": "First and Last Name",
+              "label": "Full Name",
               "validation_error_msg": "Please enter a name for the point of contact.",
               "required": true
             },
@@ -55,7 +55,7 @@
             {
               "type": "text",
               "control_id": "poc_name",
-              "label": "First and Last Name",
+              "label": "Full Name",
               "validation_error_msg": "Please enter a name for the point of contact.",
               "required": true
             },

--- a/src/sample-data/sql/forms.sql
+++ b/src/sample-data/sql/forms.sql
@@ -125,11 +125,11 @@ INSERT INTO section_question VALUES ('b0934ecc-1aa1-4e07-9cbc-f1299126aee0', 'f2
 
 -- Input(question_id, control_id, list_order, label, type, enums, attributes, required_if, show_if, required))
 
-INSERT INTO input VALUES ('80ac5f52-9ed9-4139-b5f9-7b4cebb6a8e2', 'data_producer_info_name', 0, 'First and Last Name', 'text', '{}', '{}', '[]','[]',  True);
+INSERT INTO input VALUES ('80ac5f52-9ed9-4139-b5f9-7b4cebb6a8e2', 'data_producer_info_name', 0, 'Full Name', 'text', '{}', '{}', '[]','[]',  True);
 INSERT INTO input VALUES ('80ac5f52-9ed9-4139-b5f9-7b4cebb6a8e2', 'data_producer_info_organization', 1, 'Organization', 'text', '{}', '{}', '[]','[]',  True);
 INSERT INTO input VALUES ('80ac5f52-9ed9-4139-b5f9-7b4cebb6a8e2', 'data_producer_info_email', 2, 'Email', 'email', '{}', '{}', '[]','[]',  True);
 INSERT INTO input VALUES ('80ac5f52-9ed9-4139-b5f9-7b4cebb6a8e2', 'data_producer_info_orcid', 3, 'ORCID', 'text', '{}', '{}', '[]','[]',  False);
-INSERT INTO input VALUES ('f3e2eab9-6375-4e53-9cc2-3d16f318d333', 'poc_name', 0, 'First and Last Name', 'text', '{}', '{}', '[]','[]',  True);
+INSERT INTO input VALUES ('f3e2eab9-6375-4e53-9cc2-3d16f318d333', 'poc_name', 0, 'Full Name', 'text', '{}', '{}', '[]','[]',  True);
 INSERT INTO input VALUES ('f3e2eab9-6375-4e53-9cc2-3d16f318d333', 'poc_organization', 1, 'Organization', 'text', '{}', '{}', '[]','[]',  True);
 INSERT INTO input VALUES ('f3e2eab9-6375-4e53-9cc2-3d16f318d333', 'poc_email', 2, 'Email', 'email', '{}', '{}', '[]','[]',  True);
 INSERT INTO input VALUES ('f3e2eab9-6375-4e53-9cc2-3d16f318d333', 'poc_orcid', 3, 'ORCID', 'text', '{}', '{}', '[]','[]',  False);
@@ -170,7 +170,7 @@ INSERT INTO input VALUES ('4c42796a-8ff1-444e-8fc5-82ccad82e5fb', 'data_delivery
 INSERT INTO input VALUES ('40672516-2220-4edc-8c1b-fd9f7e0b978f', 'data_product_volume_amount', 0, 'Amount', 'number', '{}', '{"min": "1"}', '[]','[]',  True);
 INSERT INTO input VALUES ('40672516-2220-4edc-8c1b-fd9f7e0b978f', 'data_product_volume_units', 1, 'Unit', 'radio', '["KB","MB","GB","TB","PB"]', '{}', '[]','[]',  True);
 INSERT INTO input VALUES ('53a0faa7-f7d4-4ce9-a9dc-a13cef44e1f3', 'example_file_url', 0, 'Sample File URL', 'text', '{}', '{}', '[]','[]',  False);
-INSERT INTO input VALUES ('f3e2eab9-6375-4e53-9cc2-3d16f318d332', 'long_term_support_poc_name', 0, 'First and Last Name', 'text', '{}', '{}', '[]','[]',  True);
+INSERT INTO input VALUES ('f3e2eab9-6375-4e53-9cc2-3d16f318d332', 'long_term_support_poc_name', 0, 'Full Name', 'text', '{}', '{}', '[]','[]',  True);
 INSERT INTO input VALUES ('f3e2eab9-6375-4e53-9cc2-3d16f318d332', 'long_term_support_poc_organization', 1, 'Organization', 'text', '{}', '{}', '[]','[]',  True);
 INSERT INTO input VALUES ('f3e2eab9-6375-4e53-9cc2-3d16f318d332', 'long_term_support_poc_email', 2, 'Email', 'email', '{}', '{}', '[]','[]',  True);
 INSERT INTO input VALUES ('f3e2eab9-6375-4e53-9cc2-3d16f318d332', 'long_term_support_poc_orcid', 3, 'ORCID', 'text', '{}', '{}', '[]','[]',  False);


### PR DESCRIPTION
# Description

Updated contact information label to full name from first and last name.

## Spec

See Ticket: https://bugs.earthdata.nasa.gov/browse/EDPUB-1213

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Pull this branch down.
3. Navigate to to the overview repo and run 'npm run start-dev' (make sure the api was rebuilt)
4. Navigate to the Dashboard and click the 'New Request'
5. Verify the form labels for 'Data Producer', 'Point of Contact', and 'Long-term Support Point of Contact' show 'Full Name' instead of 'First and Last Name.'

OR

1. Make sure all merge request checks have passed (CI/CD).
2. Pull this branch down.
3. Rebuild API to verify it builds.
4. Push out to SIT and run the added updates.sql statement.
5. Verify or have Matt Donovan verify that the form labels for 'Data Producer', 'Point of Contact', and 'Long-term Support Point of Contact' show 'Full Name' instead of 'First and Last Name.'

## Change Log

* [Updated contact information label to full name from first and last name](fb4e8d28905a602eff79006d4b73b489784c4544)