### PR TITLE
Edpub 1214 fix create update workflow validation logic

### DIFF
--- a/src/nodejs/lambda-handlers/submission.js
+++ b/src/nodejs/lambda-handlers/submission.js
@@ -143,7 +143,7 @@ async function reviewMethod(event, user) {
   const status = await db.submission.getState({ id });
   const stepType = status.step.type;
   let eventType;
-  if (approve === 'false') {
+  if (approve === 'false' || !approve) {
     eventType = 'review_rejected';
   } else if (stepType === 'review') {
     eventType = 'review_approved';

--- a/src/nodejs/lambda-handlers/workflow.js
+++ b/src/nodejs/lambda-handlers/workflow.js
@@ -7,14 +7,14 @@
 
 const db = require('database-util');
 
-async function createStep(step, stepName) {
+async function createStep(step, stepName, rollbackInfo) {
   return db.workflow.createStep({
     step_name: stepName,
     type: step.type,
     action_id: step.action_id,
     form_id: step.form_id,
     service_id: step.service_id,
-    data: step.prev_step
+    data: rollbackInfo
   });
 }
 
@@ -34,7 +34,17 @@ async function addSteps(steps, workflowId) {
         || (!nextStepName)
         || (!nextStep)
       ) { return false; }
-      await createStep(steps[nextStepName], nextStepName);
+
+      if (nextStepName !== 'data_accession_request_form'){
+        const nextStepRollbackInfo = {
+          rollback: activeStepName,
+          type: activeStep.type,
+          form_id: activeStep.form_id
+        }
+        await createStep(steps[nextStepName], nextStepName, nextStepRollbackInfo);
+      } else {
+        await createStep(steps[nextStepName], nextStepName);
+      }
       i += 1;
     }
     await db.workflow.addStep({

--- a/src/nodejs/lambda-handlers/workflow.js
+++ b/src/nodejs/lambda-handlers/workflow.js
@@ -35,16 +35,13 @@ async function addSteps(steps, workflowId) {
         || (!nextStep)
       ) { return false; }
 
-      if (nextStepName !== 'data_accession_request_form') {
-        const nextStepRollbackInfo = {
-          rollback: activeStepName,
-          type: activeStep.type,
-          form_id: activeStep.form_id
-        };
-        await createStep(steps[nextStepName], nextStepName, nextStepRollbackInfo);
-      } else {
-        await createStep(steps[nextStepName], nextStepName);
-      }
+      const nextStepRollbackInfo = {
+        rollback: activeStepName,
+        type: activeStep.type,
+        form_id: activeStep.form_id
+      };
+      await createStep(steps[nextStepName], nextStepName, nextStepRollbackInfo);
+
       i += 1;
     }
     await db.workflow.addStep({

--- a/src/nodejs/lambda-handlers/workflow.js
+++ b/src/nodejs/lambda-handlers/workflow.js
@@ -35,12 +35,12 @@ async function addSteps(steps, workflowId) {
         || (!nextStep)
       ) { return false; }
 
-      if (nextStepName !== 'data_accession_request_form'){
+      if (nextStepName !== 'data_accession_request_form') {
         const nextStepRollbackInfo = {
           rollback: activeStepName,
           type: activeStep.type,
           form_id: activeStep.form_id
-        }
+        };
         await createStep(steps[nextStepName], nextStepName, nextStepRollbackInfo);
       } else {
         await createStep(steps[nextStepName], nextStepName);


### PR DESCRIPTION
# Description

Updates logic to programmatically set rollback information to ensure that the rollback is always set to the previous step. 

## Spec


See Ticket: https://bugs.earthdata.nasa.gov/browse/EDPUB-1214

---

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Deploy the api, dashboard, and forms apps locally.
4. From the dashboard click on Workflows
5. Click on the edit button for the GHRC Default Workflow
6. Verify that the `map_question_response_to_ummc` has the following in the definition
```
"prev_step": {
    "type": "action",
    "rollback": "confirmation_form"
},
```
7. Click Submit
8. Verify that the "prev_step" object in  `map_question_response_to_ummc` has been updated to match the following
```
"prev_step": {
    "type": "review",
    "rollback": "data_publication_request_form_review"
},
```
9. For additional verification - create a new request and select GHRC as the daac
10. Follow through till the next step is Map Question Response To UMMC
11. Click on Map Question Response To UMMC
12. Enter a comment and hit "Go back"
13. Verify that the next step is "Data Publication Request Form Review
