### PR TITLE
EDPUB-1246: Fix Special Characters in Email Notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 <!-- Unreleased changes can be added here. -->
+- Updated email notification text formatting to accommodate special characters
 - Updated contact information label to full name from first and last name
 - Renames improperly named /api/data/submission/{operation} endpoints back to the intended /api/submission/{operation}.
 - Add DAAC onboard/offboard endpoints

--- a/src/nodejs/lambda-layers/message-util/src/templates/direct-message.js
+++ b/src/nodejs/lambda-layers/message-util/src/templates/direct-message.js
@@ -21,7 +21,7 @@ const getDMTemplate = (params, envUrl) => {
                <td colspan="2" style="padding:20px;">
                  <h1>Hello ${params.user.name},</h1><br><br>
                  <p>You have received a direct message on the Earthdata Pub Dashboard.</p>
-                 <h2>Message:</h2><p>${params.eventMessage.conversation_last_message}</p><br><br>
+                 <h2>Message:</h2><p style="white-space: pre;">${decodeURI(params.eventMessage.conversation_last_message)}</p><br><br>
                  
                  <p><a style="text-align: left;" href="${envUrl}/dashboard" aria-label="Visit Earthdata Pub Dashboard">${envUrl}/dashboard</a></p>
                </td>


### PR DESCRIPTION
# Description

Display special characters (especially `\n`, `\t`, `\r`, etc. correctly in the email notifications.

## Spec

See Ticket: https://bugs.earthdata.nasa.gov/browse/EDPUB-1246

Parallel PR: https://github.com/eosdis-nasa/earthdata-pub-dashboard/pull/39

---

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Deploy this branch and the API branch `EDPUB-1246-fix-special-char-issues` to SIT
3. Create a new request (no need to continue beyond selecting DAAC form.
4. Sign into another user account (to ensure you receive the email notification).
5. Navigate to the request conversation.
6. Send a message with the following text copy/pasted:
```
Test
	multiline	multitab
	with special's			 characters?
	and \n text? <---
```
7. Validate that the message is displayed as expected within the dashboard and within the email notification.
8. Send a message with the following text copy/pasted: 
```
	Another
test of \r\n\t special character's
and what they \\\ might encode/decode			as!
```
10. Validate that the message is displayed as expected within the dashboard and within the email notification.

---