### PR TITLE
Update data_poc users to producer and remove data_poc role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 
 <!-- Unreleased changes can be added here. -->
+- Update data_poc users to producer and remove data_poc and it's references
 - Created note_scope table
 - Updated metadata mapper for DAAC specific questions
 - Updated email notification text formatting to accommodate special characters

--- a/src/nodejs/lambda-handlers/notification-consumer.js
+++ b/src/nodejs/lambda-handlers/notification-consumer.js
@@ -16,7 +16,6 @@ async function sendEmailNotification({ note, emailPayload }) {
   // dict of roles for readability
   const roles = {
     data_producer: '804b335c-f191-4d26-9b98-1ec1cb62b97d',
-    data_poc: '29ccab4b-65e2-4764-83ec-77375d29af39',
     daac_staff: 'a5b4947a-67d2-434e-9889-59c2fad39676',
     daac_manager: '2aa89c57-85f1-4611-812d-b6760bb6295c',
     daac_observer: '4be6ca4d-6362-478b-8478-487a668314b1',
@@ -27,19 +26,19 @@ async function sendEmailNotification({ note, emailPayload }) {
 
   switch (emailPayload.event_type) {
     case 'form_request':
-      userRole = [roles.data_producer, roles.data_poc];
+      userRole = [roles.data_producer];
       break;
     case 'form_submitted':
       userRole = [roles.daac_staff, roles.daac_manager];
       break;
     case 'review_approved':
-      userRole = [roles.data_producer, roles.data_poc];
+      userRole = [roles.data_producer];
       break;
     case 'review_rejected':
-      userRole = [roles.data_producer, roles.data_poc];
+      userRole = [roles.data_producer];
       break;
     case 'metadata_updated':
-      userRole = [roles.data_producer, roles.data_poc];
+      userRole = [roles.data_producer];
       break;
     case 'action_request_no_id':
       userRole = [roles.daac_staff, roles.daac_manager];
@@ -47,7 +46,6 @@ async function sendEmailNotification({ note, emailPayload }) {
     case 'direct_message':
       userRole = [
         roles.data_producer,
-        roles.data_poc,
         roles.daac_staff,
         roles.daac_manager,
         roles.admin,
@@ -55,7 +53,7 @@ async function sendEmailNotification({ note, emailPayload }) {
       ];
       break;
     default:
-      userRole = [roles.data_producer, roles.data_poc, roles.daac_staff, roles.daac_manager];
+      userRole = [roles.data_producer, roles.daac_staff, roles.daac_manager];
       break;
   }
   const users = await db.note.getEmails({

--- a/src/postgres/7-seed.sql
+++ b/src/postgres/7-seed.sql
@@ -271,7 +271,6 @@ INSERT INTO edpuser_edpgroup VALUES ('1b10a09d-d342-4eee-a9eb-c99acd2dde17', '4d
 
 -- Role(id, short_name, long_name, description)
 INSERT INTO edprole VALUES ('804b335c-f191-4d26-9b98-1ec1cb62b97d', 'data_producer', 'Data Producer', 'The person who is primarily responsible for the data themselves. Often the PI of the project that generated the data. This role will be able to create a Request and edit their created or assigned Requests.');
-INSERT INTO edprole VALUES ('29ccab4b-65e2-4764-83ec-77375d29af39', 'data_poc', 'Data Point of Contact', 'The person who is filling out the Earthdata Pub Forms and expected to answer questions about the Request. Can be the same as the DP and has the same permissions as a DP.');
 INSERT INTO edprole VALUES ('a5b4947a-67d2-434e-9889-59c2fad39676', 'staff', 'DAAC Staff', 'The DAAC staff member who guides the Request through Earthdata Pub workflows and iterates with the PoC on questions. This role will be able to add and edit requests.');
 INSERT INTO edprole VALUES ('2aa89c57-85f1-4611-812d-b6760bb6295c', 'manager', 'DAAC Data Manager', 'The DAAC staff member who manages all DAAC Requests. Managers assign a Request to Staff. There may be multiple DAAC Data Managers per DAAC. Some DAACs may choose to combine the Manager and Staff roles by assigning staff to both.');
 INSERT INTO edprole VALUES ('4be6ca4d-6362-478b-8478-487a668314b1', 'observer', 'DAAC Observer', 'A DAAC or ESDIS staff member who is interested in monitoring progress in Earthdata Pub but does not need edit or write permission. This can be a DAAC Data Staff or similar.');
@@ -359,19 +358,6 @@ INSERT INTO edprole_privilege VALUES ('804b335c-f191-4d26-9b98-1ec1cb62b97d', 'F
 INSERT INTO edprole_privilege VALUES ('804b335c-f191-4d26-9b98-1ec1cb62b97d', 'FORM_READ');
 INSERT INTO edprole_privilege VALUES ('804b335c-f191-4d26-9b98-1ec1cb62b97d', 'FORM_UPDATE');
 INSERT INTO edprole_privilege VALUES ('804b335c-f191-4d26-9b98-1ec1cb62b97d', 'FORM_DELETE');
-
---RolePrivilege(edprole_id, privilege) Data Point of Contact
-INSERT INTO edprole_privilege VALUES ('29ccab4b-65e2-4764-83ec-77375d29af39', 'REQUEST_INITIALIZE');
-INSERT INTO edprole_privilege VALUES ('29ccab4b-65e2-4764-83ec-77375d29af39', 'REQUEST_READ');
-INSERT INTO edprole_privilege VALUES ('29ccab4b-65e2-4764-83ec-77375d29af39', 'REQUEST_SUBMIT');
-INSERT INTO edprole_privilege VALUES ('29ccab4b-65e2-4764-83ec-77375d29af39', 'REQUEST_LOCK');
-INSERT INTO edprole_privilege VALUES ('29ccab4b-65e2-4764-83ec-77375d29af39', 'REQUEST_UNLOCK');
-INSERT INTO edprole_privilege VALUES ('29ccab4b-65e2-4764-83ec-77375d29af39', 'DAAC_READ');
-INSERT INTO edprole_privilege VALUES ('29ccab4b-65e2-4764-83ec-77375d29af39', 'NOTE_REPLY');
-INSERT INTO edprole_privilege VALUES ('29ccab4b-65e2-4764-83ec-77375d29af39', 'FORM_CREATE');
-INSERT INTO edprole_privilege VALUES ('29ccab4b-65e2-4764-83ec-77375d29af39', 'FORM_READ');
-INSERT INTO edprole_privilege VALUES ('29ccab4b-65e2-4764-83ec-77375d29af39', 'FORM_UPDATE');
-INSERT INTO edprole_privilege VALUES ('29ccab4b-65e2-4764-83ec-77375d29af39', 'FORM_DELETE');
 
 --RolePrivilege(edprole_id, privilege) DAAC Staff
 INSERT INTO edprole_privilege VALUES ('a5b4947a-67d2-434e-9889-59c2fad39676', 'REQUEST_INITIALIZE');

--- a/src/postgres/9-updates.sql
+++ b/src/postgres/9-updates.sql
@@ -227,3 +227,9 @@ CREATE TABLE IF NOT EXISTS note_scope (
 --4/23/2024 Fixing daac data manager permissions
 INSERT INTO edprole_privilege VALUES ('2aa89c57-85f1-4611-812d-b6760bb6295c', 'METRICS_READ');
 
+UPDATE edpuser_edprole
+SET edprole_id = '804b335c-f191-4d26-9b98-1ec1cb62b97d'
+WHERE edprole_id = '29ccab4b-65e2-4764-83ec-77375d29af39';
+
+delete from edprole_privilege where edprole_id='29ccab4b-65e2-4764-83ec-77375d29af39';
+delete from edprole where id='29ccab4b-65e2-4764-83ec-77375d29af39'


### PR DESCRIPTION
# Description
Update data_poc users to producer and remove data_poc role.

## Validation

### To Validate

1. Make sure all merge request checks have passed (CI/CD).
1. From earthdata-pub-api, run the api from the latest develop branch.
1. Log in as 'Earthdata Pub System' and add the role, 'Data Point of Contact'.
1. Log out of the dashboard.
1. Copy paste the lines 230 - 235 from 9-updates.sql, and run in your local database.
1. Log back into the Dashboard and observe your user is now data producer.
1. Rebuild the api with this branch.
1. Verify the api builds without error.
1. Log back in as Earthdata Pub System.
1. Click on the 'Hi, Earthdata Pub System' at the top.
1. Verify you can no longer add 'Data Point of Contact' as a role.

## Change Log
Update data_poc users to producer and remove data_poc role. (669bca12335aa4962eae8aae6571553eacef20b0).  