### PR TITLE
Edpub 1001 add metadata push for gesdisc

### DIFF
--- a/src/postgres/7-seed.sql
+++ b/src/postgres/7-seed.sql
@@ -556,7 +556,8 @@ INSERT INTO step_edge VALUES ('7843dc6d-f56d-488a-9193-bb7c0dc3696d', 'init', 'd
 INSERT INTO step_edge VALUES ('7843dc6d-f56d-488a-9193-bb7c0dc3696d', 'data_accession_request_form', 'data_accession_request_form_review');
 INSERT INTO step_edge VALUES ('7843dc6d-f56d-488a-9193-bb7c0dc3696d', 'data_accession_request_form_review', 'data_publication_request_form');
 INSERT INTO step_edge VALUES ('7843dc6d-f56d-488a-9193-bb7c0dc3696d', 'data_publication_request_form', 'data_publication_request_form_review');
-INSERT INTO step_edge VALUES ('7843dc6d-f56d-488a-9193-bb7c0dc3696d', 'data_publication_request_form_review', 'send_metadata_to_ges_disc');
+INSERT INTO step_edge VALUES ('7843dc6d-f56d-488a-9193-bb7c0dc3696d', 'data_publication_request_form_review', 'map_question_response_to_ummc');
+INSERT INTO step_edge VALUES ('7843dc6d-f56d-488a-9193-bb7c0dc3696d', 'map_question_response_to_ummc', 'send_metadata_to_ges_disc');
 INSERT INTO step_edge VALUES ('7843dc6d-f56d-488a-9193-bb7c0dc3696d', 'send_metadata_to_ges_disc', 'data_publication_request_form_management_review');
 INSERT INTO step_edge VALUES ('7843dc6d-f56d-488a-9193-bb7c0dc3696d', 'data_publication_request_form_management_review', 'data_publication_request_form_uwg_review');
 INSERT INTO step_edge VALUES ('7843dc6d-f56d-488a-9193-bb7c0dc3696d', 'data_publication_request_form_uwg_review', 'data_publication_request_form_esdis_review');

--- a/src/postgres/7-seed.sql
+++ b/src/postgres/7-seed.sql
@@ -8,6 +8,7 @@ INSERT INTO form VALUES ('de7e5c40-584a-493b-919d-8f7f3f1e9e3c', 'confirmation_f
 INSERT INTO action VALUES ('3fe93672-cd91-45d4-863b-c6d0d63f8c8c', 'send_to_mmt', 1, 'Send To MMT Action', 'This action is used to send collection metadata from EDPub to MMT.', 'sendToMMT.js');
 INSERT INTO action VALUES ('f812eb99-7c4a-46a8-8d8f-30ae509fe21c', 'map_edpub_to_ummc', 1, 'Map EDPub To UMMC Action', 'This action is map EDPub question reponses to a JSON UMMC format.', 'mapEDPubToUmmc.js');
 INSERT INTO action VALUES ('6d872804-609b-4e5d-a80c-143908051e07', 'push_metadata_to_daac', 1, 'Pushes Metadata to a Daac Endpoint', 'This action is used to push metadata to a DAAC endpoint.', 'pushMetadataToDaac.js');
+INSERT INTO action VALUES ('09293035-2d31-44d3-a6b0-675f10dc34bf', 'push_metadata_to_gesdisc', 1, 'Push Metadata to GES DISC Endpoint', 'This action is used to push metadata to the GES DISC meditor instance', 'pushMetadataToGesdisc.js');
 
 -- Section(id, form_id, heading, list_order, daac_id)
 INSERT INTO section VALUES ('1b4f110b-fea3-444f-b52c-c85008cf3b50', '6c544723-241c-4896-a38c-adbc0a364293', 'Contact Information', 0, '[]', '[]', NULL);
@@ -546,7 +547,8 @@ INSERT INTO step_edge VALUES ('a218f99d-cfc1-44e5-b203-3e447e1c1275', 'push_to_o
 
 -- GES DISC 
 -- Step(step_id, step_name, type, action_id, form_id, service_id, data)
-INSERT INTO step(step_id, step_name, type, data) VALUES ('e62e9548-b350-40ec-b1bc-21a75e5f0407', 'data_publication_request_form_management_review', 'review', '{"rollback":"data_publication_request_form_review","type": "review","form_id":"19025579-99ca-4344-8610-704dae626343"}');
+INSERT INTO step(step_id, step_name, type, action_id, data) VALUES ('a9c55c56-8fd7-4bd1-89aa-0cf9e28da07e', 'send_metadata_to_ges_disc', 'action', '09293035-2d31-44d3-a6b0-675f10dc34bf', '{"rollback":"data_publication_request_form_review","type": "review","form_id":"19025579-99ca-4344-8610-704dae626343"}');
+INSERT INTO step(step_id, step_name, type, data) VALUES ('e62e9548-b350-40ec-b1bc-21a75e5f0407', 'data_publication_request_form_management_review', 'review', '{"rollback":"sent_metadata_to_gesdisc,"type": "action"}');
 INSERT INTO step(step_id, step_name, type, data) VALUES ('c81066db-0566-428d-87e8-94169ce5a9b9', 'data_publication_request_form_uwg_review', 'review', '{"rollback":"data_publication_request_form_management_review","type": "review","form_id":"19025579-99ca-4344-8610-704dae626343"}');
 INSERT INTO step(step_id, step_name, type, data) VALUES ('7838ed18-4ecd-499e-9a47-91fd181cbfc7', 'data_publication_request_form_esdis_review', 'review', '{"rollback":"data_publication_request_form_uwg_review","type": "review","form_id":"19025579-99ca-4344-8610-704dae626343"}');
 -- StepEdge(workflow_id, step_name, next_step_name)
@@ -554,7 +556,8 @@ INSERT INTO step_edge VALUES ('7843dc6d-f56d-488a-9193-bb7c0dc3696d', 'init', 'd
 INSERT INTO step_edge VALUES ('7843dc6d-f56d-488a-9193-bb7c0dc3696d', 'data_accession_request_form', 'data_accession_request_form_review');
 INSERT INTO step_edge VALUES ('7843dc6d-f56d-488a-9193-bb7c0dc3696d', 'data_accession_request_form_review', 'data_publication_request_form');
 INSERT INTO step_edge VALUES ('7843dc6d-f56d-488a-9193-bb7c0dc3696d', 'data_publication_request_form', 'data_publication_request_form_review');
-INSERT INTO step_edge VALUES ('7843dc6d-f56d-488a-9193-bb7c0dc3696d', 'data_publication_request_form_review', 'data_publication_request_form_management_review');
+INSERT INTO step_edge VALUES ('7843dc6d-f56d-488a-9193-bb7c0dc3696d', 'data_publication_request_form_review', 'send_metadata_to_ges_disc');
+INSERT INTO step_edge VALUES ('7843dc6d-f56d-488a-9193-bb7c0dc3696d', 'send_metadata_to_ges_disc', 'data_publication_request_form_management_review');
 INSERT INTO step_edge VALUES ('7843dc6d-f56d-488a-9193-bb7c0dc3696d', 'data_publication_request_form_management_review', 'data_publication_request_form_uwg_review');
 INSERT INTO step_edge VALUES ('7843dc6d-f56d-488a-9193-bb7c0dc3696d', 'data_publication_request_form_uwg_review', 'data_publication_request_form_esdis_review');
 INSERT INTO step_edge VALUES ('7843dc6d-f56d-488a-9193-bb7c0dc3696d', 'data_publication_request_form_esdis_review', 'close');

--- a/src/postgres/9-updates.sql
+++ b/src/postgres/9-updates.sql
@@ -315,3 +315,17 @@ WHERE edprole_id = '29ccab4b-65e2-4764-83ec-77375d29af39';
 
 delete from edprole_privilege where edprole_id='29ccab4b-65e2-4764-83ec-77375d29af39';
 delete from edprole where id='29ccab4b-65e2-4764-83ec-77375d29af39'
+
+--06/07/2024 adding push metadata to GES DISC endpoint
+INSERT INTO action VALUES ('09293035-2d31-44d3-a6b0-675f10dc34bf', 'push_metadata_to_gesdisc', 1, 'Push Metadata to GES DISC Endpoint', 'This action is used to push metadata to the GES DISC meditor instance', 'pushMetadataToGesdisc.js');
+
+INSERT INTO step(step_id, step_name, type, action_id, data) VALUES ('a9c55c56-8fd7-4bd1-89aa-0cf9e28da07e', 'send_metadata_to_ges_disc', 'action', '09293035-2d31-44d3-a6b0-675f10dc34bf', '{"rollback":"data_publication_request_form_review","type": "review","form_id":"19025579-99ca-4344-8610-704dae626343"}');
+
+DELETE FROM step_edge
+WHERE workflow_id = '7843dc6d-f56d-488a-9193-bb7c0dc3696d' 
+AND step_name = 'data_publication_request_form_review' 
+AND next_step_name = 'data_publication_request_form_management_review';
+
+INSERT INTO step_edge VALUES ('7843dc6d-f56d-488a-9193-bb7c0dc3696d', 'data_publication_request_form_review', 'map_question_response_to_ummc');
+INSERT INTO step_edge VALUES ('7843dc6d-f56d-488a-9193-bb7c0dc3696d', 'map_question_response_to_ummc', 'send_metadata_to_ges_disc');
+INSERT INTO step_edge VALUES ('7843dc6d-f56d-488a-9193-bb7c0dc3696d', 'send_metadata_to_ges_disc', 'data_publication_request_form_management_review');

--- a/terraform/aws_secrets/main.tf
+++ b/terraform/aws_secrets/main.tf
@@ -25,3 +25,17 @@ resource "aws_secretsmanager_secret_version" "ornl_endpoint" {
       "ornl_endpoint_access_token" = var.ornl_endpoint_access_token
     })
 }
+
+#GESDISC endpoint access
+resource "aws_secretsmanager_secret" "gesdisc_endpoint"{
+  name = "gesdisc_endpoint"
+  description = "GESDISC endpoint and credentials"
+}
+
+resource "aws_secretsmanager_secret_version" "gesdisc_endpoint"{
+  secret_id = aws_secretsmanager_secret.gesdisc_endpoint.id
+    secret_string = jsonencode({
+      "gesdisc_endpoint_url" = var.gesdisc_endpoint_url
+      "gesdisc_endpoint_access_token" = var.gesdisc_endpoint_access_token
+    })
+}

--- a/terraform/aws_secrets/outputs.tf
+++ b/terraform/aws_secrets/outputs.tf
@@ -5,3 +5,7 @@ output "ses_access_creds_arn" {
 output "ornl_endpoint_arn"{
   value = aws_secretsmanager_secret.ornl_endpoint.arn
 }
+
+output "gesdisc_endpoint_arn"{
+  value = aws_secretsmanager_secret.gesdisc_endpoint.arn
+}

--- a/terraform/aws_secrets/variables.tf
+++ b/terraform/aws_secrets/variables.tf
@@ -13,3 +13,11 @@ variable "ornl_endpoint_url" {
 variable "ornl_endpoint_access_token" {
   type = string
 }
+
+variable "gesdisc_endpoint_url"{
+  type = string
+}
+
+variable "gesdisc_endpoint_access_token"{
+  type = string
+}

--- a/terraform/iam/edpub_lambda_policy.json
+++ b/terraform/iam/edpub_lambda_policy.json
@@ -72,7 +72,8 @@
       ],
       "Resource":[
         "${ses_access_creds_arn}",
-        "${ornl_endpoint_arn}"
+        "${ornl_endpoint_arn}",
+        "${gesdisc_endpoint_arn}"
       ]
     }
   ]

--- a/terraform/iam/template_files.tf
+++ b/terraform/iam/template_files.tf
@@ -22,6 +22,7 @@ data "template_file" "edpub_lambda_policy" {
     edpub_workflow_sqs_arn = var.edpub_workflow_sqs_arn
     ses_access_creds_arn = var.ses_access_creds_arn
     ornl_endpoint_arn = var.ornl_endpoint_arn
+    gesdisc_endpoint_arn = var.gesdisc_endpoint_arn
   }
 }
 

--- a/terraform/iam/variables.tf
+++ b/terraform/iam/variables.tf
@@ -61,3 +61,7 @@ variable "ses_access_creds_arn" {
 variable "ornl_endpoint_arn" {
   type = string
 }
+
+variable "gesdisc_endpoint_arn"{
+  type = string
+}

--- a/terraform/lambda/variables.tf
+++ b/terraform/lambda/variables.tf
@@ -189,3 +189,7 @@ variable "ses_access_creds_arn" {
 variable "ornl_endpoint_arn" {
   type = string
 }
+
+variable "gesdisc_endpoint_arn"{
+  type = string
+}

--- a/terraform/modules.tf
+++ b/terraform/modules.tf
@@ -17,6 +17,7 @@ module "iam_roles" {
   permissions_boundary_arn = var.permissions_boundary_arn
   ses_access_creds_arn = module.aws_secrets.ses_access_creds_arn
   ornl_endpoint_arn = module.aws_secrets.ornl_endpoint_arn
+  gesdisc_endpoint_arn = module.aws_secrets.gesdisc_endpoint_arn
 }
 
 module "s3" {
@@ -32,6 +33,8 @@ module "aws_secrets" {
   ses_secret_access_key = var.ses_secret_access_key
   ornl_endpoint_url = var.ornl_endpoint_url
   ornl_endpoint_access_token = var.ornl_endpoint_access_token
+  gesdisc_endpoint_url = var.gesdisc_endpoint_url
+  gesdisc_endpoint_access_token = var.gesdisc_endpoint_access_token
 }
 
 module "lambda_functions" {
@@ -85,6 +88,7 @@ module "lambda_functions" {
   ses_from_email = var.ses_from_email
   ses_access_creds_arn = module.aws_secrets.ses_access_creds_arn
   ornl_endpoint_arn = module.aws_secrets.ornl_endpoint_arn
+  gesdisc_endpoint_arn = module.aws_secrets.gesdisc_endpoint_arn
 }
 
 module "apigateway_endpoints" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -123,3 +123,11 @@ variable "ornl_endpoint_url" {
 variable "ornl_endpoint_access_token" {
   type = string
 }
+
+variable "gesdisc_endpoint_url"{
+  type = string
+}
+
+variable "gesdisc_endpoint_access_token"{
+  type = string
+}


### PR DESCRIPTION
# Description

Adds support for GES DISC push to daac step.

## Spec

See Ticket: [EDPUB-1001](https://bugs.earthdata.nasa.gov/browse/EDPUB-1001)

---

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Create a GESDISC submission.
4. Complete all forms and approve them
5. Confirm it progresses through the automated steps
6. Confirm with GESDISC metadata was received.

Notice this has been validated by GESDISC.  This must be deployed to test but deploying and undeploying the merge for testing will cause issues with AWS secrets that will break other deployments for at least 7 days.
---

## Change Log

Adds support for GES DISC push to daac step.

* [Add _____](link to commitid)
* [Fix _____](link to commitid)