### PR TITLE
EDPUB- 1285: Add list users filter by role group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updates step promotion to update set event type programmatically.
 - Update cloud metrics logging
 - Reimplemented custom MFA flow
+- Added filter by group and role id to the users endpont
 
 ## 1.0.20
 

--- a/src/nodejs/controllers/proxy.js
+++ b/src/nodejs/controllers/proxy.js
@@ -399,7 +399,9 @@ module.exports.userFindAll = function userFindAll(req, res, next) {
           sort: params.sort.value,
           order: params.order.value,
           per_page: params.per_page.value,
-          page: params.page.value
+          page: params.page.value,
+          group_id: params.group_id.value,
+          role_id: params.role_id.value
     },
     context: { user_id: req.user_id }
   };

--- a/src/nodejs/controllers/static/login.html
+++ b/src/nodejs/controllers/static/login.html
@@ -181,18 +181,6 @@ li label {
             <td>Full Name</td>
             <td id="user-info-name"></td>
           </tr>
-          <tr>
-            <td>Email</td>
-            <td id="user-info-email"></td>
-          </tr>
-          <tr>
-            <td>Last Login</td>
-            <td id="user-info-last-login"></td>
-          </tr>
-          <tr>
-            <td>Registered</td>
-            <td id="user-info-registered"></td>
-          </tr>
         </table>
       </div>
     </div>
@@ -218,10 +206,7 @@ li label {
     const loginButton = document.getElementById('btn-login');
     const info = {
       id: document.getElementById('user-info-id'),
-      name: document.getElementById('user-info-name'),
-      email: document.getElementById('user-info-email'),
-      last_login: document.getElementById('user-info-last-login'),
-      registered: document.getElementById('user-info-registered')
+      name: document.getElementById('user-info-name')
     }
     userInfoPanel.style.display = "none";
     loginButton.style.display = "none";
@@ -286,9 +271,6 @@ li label {
         const user = users[pick];
         info.id.innerText = user.id;
         info.name.innerText = user.name;
-        info.email.innerText = user.email;
-        info.last_login.innerText = user.last_login;
-        info.registered.innerText = user.registered;
       }
     }
 

--- a/src/nodejs/lambda-layers/database-util/src/query/user.js
+++ b/src/nodejs/lambda-layers/database-util/src/query/user.js
@@ -75,10 +75,20 @@ const refs = {
     src: group.userJoin,
     on: { left: fieldMap.id, right: 'group_agg.edpuser_id' }
   },
+  simple_group: {
+    type: 'left_join',
+    src: 'edpuser_edpgroup',
+    on: { left: fieldMap.id, right: 'edpuser_edpgroup.edpuser_id' }
+  },
   role: {
     type: 'left_join',
     src: role.userJoin,
     on: { left: fieldMap.id, right: 'role_agg.edpuser_id' }
+  },
+  simple_role: {
+    type: 'left_join',
+    src: 'edpuser_edprole',
+    on: { left: fieldMap.id, right: 'edpuser_edprole.edpuser_id' }
   },
   user_permission_submission: {
     type: 'left_join',
@@ -220,31 +230,27 @@ const find = ({ id, name, email, sort, order, per_page, page }) => sql.select({
   ...(page ? { offset: page } : {})
 });
 
-const findAll = ({name, email, sort, order, per_page, page}) => sql.select({
-    fields: fields(allFields),
-    from: {
-      base: table,
-      joins: [
-        refs.group,
-        refs.role,
-        refs.user_permission_submission,
-        refs.user_subscription_action,
-        refs.user_subscription_form,
-        refs.user_subscription_service,
-        refs.user_subscription_submission,
-        refs.user_subscription_workflow
-      ]
-    },
-    where: {
-      filters: [
-          ...(name ? [{ field: 'edpuser.name', like: 'name' }] : []),
-          ...(email ? [{ field: 'edpuser.email', like: 'email'}] : [])
-      ]
-    },
-    ...(sort ? { sort } : {}),
-    ...(order ? { order } : {}),
-    ...(per_page ? { limit: per_page } : {}),
-    ...(page ? { offset: page } : {})
+const findAll = ({name, email, sort, order, per_page, page, group_id, role_id}) => sql.select({
+  fields: fields(['id', 'name']),
+  from: {
+    base: table,
+    joins: [
+      refs.simple_group,
+      refs.simple_role
+    ]
+  },
+  where: {
+    filters: [
+      ...(name ? [{ field: 'edpuser.name', like: 'name' }] : []),
+      ...(email ? [{ field: 'edpuser.email', like: 'email'}] : []),
+      ...(group_id ? [{ field: 'edpuser_edpgroup.edpgroup_id', param: 'group_id' }] : []),
+      ...(role_id ? [{ field: 'edpuser_edprole.edprole_id', param: 'role_id' }] : []),
+    ]
+  },
+  ...(sort ? { sort } : {}),
+  ...(order ? { order } : {}),
+  ...(per_page ? { limit: per_page } : {}),
+  ...(page ? { offset: page } : {})
 });
 
 const findById = () => sql.select({

--- a/src/openapi/openapi.json
+++ b/src/openapi/openapi.json
@@ -5914,6 +5914,22 @@
             "schema": {
               "type": "number"
             }
+          },
+          {
+            "name": "group_id",
+            "in": "query",
+            "description": "Group id to filter results on.",
+            "schema": {
+              "$ref": "#/components/schemas/UUID"
+            }
+          },
+          {
+            "name": "role_id",
+            "in": "query",
+            "description": "Role id to filter results on.",
+            "schema": {
+              "$ref": "#/components/schemas/UUID"
+            }
           }
         ],
         "responses": {

--- a/src/postgres/7-seed.sql
+++ b/src/postgres/7-seed.sql
@@ -548,7 +548,7 @@ INSERT INTO step_edge VALUES ('a218f99d-cfc1-44e5-b203-3e447e1c1275', 'push_to_o
 -- GES DISC 
 -- Step(step_id, step_name, type, action_id, form_id, service_id, data)
 INSERT INTO step(step_id, step_name, type, action_id, data) VALUES ('a9c55c56-8fd7-4bd1-89aa-0cf9e28da07e', 'send_metadata_to_ges_disc', 'action', '09293035-2d31-44d3-a6b0-675f10dc34bf', '{"rollback":"data_publication_request_form_review","type": "review","form_id":"19025579-99ca-4344-8610-704dae626343"}');
-INSERT INTO step(step_id, step_name, type, data) VALUES ('e62e9548-b350-40ec-b1bc-21a75e5f0407', 'data_publication_request_form_management_review', 'review', '{"rollback":"sent_metadata_to_gesdisc,"type": "action"}');
+INSERT INTO step(step_id, step_name, type, data) VALUES ('e62e9548-b350-40ec-b1bc-21a75e5f0407', 'data_publication_request_form_management_review', 'review', '{"rollback": "send_metadata_to_gesdisc", "type": "action"}');
 INSERT INTO step(step_id, step_name, type, data) VALUES ('c81066db-0566-428d-87e8-94169ce5a9b9', 'data_publication_request_form_uwg_review', 'review', '{"rollback":"data_publication_request_form_management_review","type": "review","form_id":"19025579-99ca-4344-8610-704dae626343"}');
 INSERT INTO step(step_id, step_name, type, data) VALUES ('7838ed18-4ecd-499e-9a47-91fd181cbfc7', 'data_publication_request_form_esdis_review', 'review', '{"rollback":"data_publication_request_form_uwg_review","type": "review","form_id":"19025579-99ca-4344-8610-704dae626343"}');
 -- StepEdge(workflow_id, step_name, next_step_name)


### PR DESCRIPTION
# Description

Added ability to filter /users endpoint by role/group id.

## Spec

See Ticket:  https://bugs.earthdata.nasa.gov/browse/EDPUB-1285

---

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Deploy this branch and the corresponding dashboard branch locally.
3. Create a test user with group ASDC and role Data Producer.
4. Use the swagger API docs to test filtering the /api/data/users endpoint based on the group and role id

---