### PR TITLE
Edpub 1248 cloud metrics withdrawn requests

### DIFF
--- a/src/nodejs/lambda-handlers/submission.js
+++ b/src/nodejs/lambda-handlers/submission.js
@@ -220,7 +220,7 @@ async function withdrawMethod(event, user) {
   const submissionMetrics = await db.metrics.getSubmissions({
     submissionId: id
   });
-  
+
   const eventMessage = {
     event_type: 'workflow_completed',
     submission_id: id,

--- a/src/nodejs/lambda-handlers/submission.js
+++ b/src/nodejs/lambda-handlers/submission.js
@@ -216,8 +216,23 @@ async function unlockMethod(event, user) {
 
 async function withdrawMethod(event, user) {
   const { id } = event;
+  const status = await db.submission.getState({ id });
+  const submissionMetrics = await db.metrics.getSubmissions({
+    submissionId: id
+  });
+  
+  const eventMessage = {
+    event_type: 'workflow_completed',
+    submission_id: id,
+    conversation_id: status.conversation_id,
+    workflow_id: status.workflow_id,
+    step_name: 'withdrawn',
+    time_to_publish: Math.round(submissionMetrics[0].time_to_publish)
+  };
+
   const approvedUserPrivileges = ['REQUEST_ADMINREAD', 'ADMIN', 'REQUEST_DAACREAD'];
   if (approvedUserPrivileges.some((privilege) => user.user_privileges.includes(privilege))) {
+    await msg.sendEvent(eventMessage);
     return db.submission.withdrawSubmission({ id });
   }
   return db.submission.findById({ id });

--- a/src/nodejs/lambda-handlers/test/handlers/submission.test.js
+++ b/src/nodejs/lambda-handlers/test/handlers/submission.test.js
@@ -202,7 +202,7 @@ describe('submission', () => {
       id: 'test id'
     };
 
-    db.submission.getState.mockReturnValue({ conversation_id: 'test conversation', workflow_id: 'test workflow'});
+    db.submission.getState.mockReturnValue({ conversation_id: 'test conversation', workflow_id: 'test workflow' });
     db.metrics.getSubmissions.mockImplementation(async (args) => {
       expect(args).toEqual({
         submissionId: 'test id'

--- a/src/nodejs/lambda-handlers/test/handlers/submission.test.js
+++ b/src/nodejs/lambda-handlers/test/handlers/submission.test.js
@@ -34,6 +34,8 @@ db.submission.copyFormData = jest.fn();
 db.submission.copyActionData = jest.fn();
 db.submission.setSubmissionCopy = jest.fn();
 db.submission.updateSubmissionData = jest.fn();
+db.metrics = jest.fn();
+db.metrics.getSubmissions = jest.fn();
 
 msg.sendEvent = jest.fn();
 
@@ -199,6 +201,19 @@ describe('submission', () => {
       },
       id: 'test id'
     };
+
+    db.submission.getState.mockReturnValue({ conversation_id: 'test conversation', workflow_id: 'test workflow'});
+    db.metrics.getSubmissions.mockImplementation(async (args) => {
+      expect(args).toEqual({
+        submissionId: 'test id'
+      });
+      return [
+        {
+          time_to_publish: null
+        }
+      ];
+    });
+
     db.user.findById.mockReturnValueOnce({ user_privileges: ['REQUEST_ADMINREAD'] });
     db.user.findById.mockReturnValueOnce({ user_privileges: ['NO_PRIVILEGES'] });
     db.submission.findById.mockReturnValueOnce({ msg: 'test submission' });

--- a/src/nodejs/lambda-layers/database-util/src/query/metrics.js
+++ b/src/nodejs/lambda-layers/database-util/src/query/metrics.js
@@ -96,7 +96,7 @@ const getSubmissions = (params) => sql.select({
     'submission.hidden', 
     'submission_status.*',
     'submission_metrics.accession_rejected',
-    `CASE WHEN submission_status.step_name = 'close' 
+    `CASE WHEN (submission_status.step_name = 'close' OR submission.hidden IS TRUE)
       THEN EXTRACT(EPOCH FROM (last_change - created_at)) ELSE NULL END 
       as time_to_publish`
   ],


### PR DESCRIPTION
# Description

Logs an event for cloud metrics when a submission is withdrawn 

## Spec

See Ticket: https://bugs.earthdata.nasa.gov/browse/EDPUB-1248

---

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Start EDPUB locally
4. Create a new submission
5. From the request page withdraw the submission
6. Check the metrics table in a db visualizer and verify that an entry was added that contains `"step_name": "withdrawn",
    "event_type": "workflow_completed"`

---

## Change Log

* Reports withdrawn requests as complete in cloud metrics