### PR TITLE
limiting emails by visibility constraints

### DIFF
--- a/src/nodejs/lambda-handlers/notification-consumer.js
+++ b/src/nodejs/lambda-handlers/notification-consumer.js
@@ -57,6 +57,7 @@ async function sendEmailNotification({ note, emailPayload, usersList }) {
   }
   let users = usersList ? await db.user.getEmails({ user_list: usersList })
     : await db.note.getEmails({
+      noteId: note.id,
       conversationId: note.conversation_id,
       senderId: note.sender_edpuser_id,
       userRole

--- a/src/nodejs/lambda-layers/database-util/src/query/sql-builder.js
+++ b/src/nodejs/lambda-layers/database-util/src/query/sql-builder.js
@@ -134,7 +134,8 @@ const complexTypes = {
   json_agg: jsonAgg,
   json_merge_agg: jsonMergeAgg,
   json_obj: jsonObj,
-  literal: strLiteral
+  literal: strLiteral,
+  any: anyClause
 };
 
 module.exports = complexTypes;


### PR DESCRIPTION
# Description

Filters email notifications based on the visibility constraints placed upon the note.

## Spec

See Ticket: https://bugs.earthdata.nasa.gov/browse/EDPUB-1407

---

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches to SIT.
3. Log in with a DAAC Staff account
4. Create a request
5. Navigate to the request overview page.
6. Add a contributor who's email you have access to and who has a different role (Data Producer/ UWG Memeber etc)
7. Navigate to the conversation page and enter a comment with no visibility selections
8. Validate that both the DAAC Staff and other account both receive the email
9. Enter a new comment limited to just DAAC Staff members
10. Validate that only the DAAC Staff account received the email.

---

## Change Log

* Fixes issue with email visibility not matching note scope