### PR TITLE
Fixes the add questions endpoint

### DIFF
--- a/src/nodejs/lambda-handlers/questions.js
+++ b/src/nodejs/lambda-handlers/questions.js
@@ -6,7 +6,7 @@
 
 const db = require('database-util');
 
-const editPerms = { privilege: ['ADMIN'] };
+const editPerms = { privilege: ['ADMIN', 'FORM_CREATE'] };
 const readPerms = { privilege: ['ADMIN', 'QUESTION_READ'] };
 
 async function hasPerms(uid, perms) {

--- a/src/nodejs/lambda-layers/database-util/src/query/question.js
+++ b/src/nodejs/lambda-layers/database-util/src/query/question.js
@@ -124,12 +124,17 @@ const update = ({ daac_ids }) => `
   long_name = EXCLUDED.long_name, text = EXCLUDED.text, help = EXCLUDED.help,
   required = EXCLUDED.required, created_at = EXCLUDED.created_at, EXCLUDED.daac_ids
   RETURNING *`;
-const add = ({ daac_ids }) => `
-  WITH new_question AS (${update({ daac_ids })}),
+const add = (params) => `
+  WITH new_question AS (INSERT INTO question (${params.payload.id ? 'id,': ''} short_name, version, long_name, text, 
+  help, required, ${params.payload.created_at ? 'created_at,': ''} daac_ids)
+  VALUES (${params.payload.id ? '{{payload.id}},': ''} {{payload.short_name}}, {{payload.version}}, {{payload.long_name}}, {{payload.text}}, {{payload.help}}, 
+  {{payload.required}}, ${params.payload.created_at ? '{{payload.created_at}},': ''} ${params.payload.daac_ids && params.payload.daac_ids.length > 0 ? `ARRAY['${params.payload.daac_ids.join('\',\'')}']::UUID[]` : `ARRAY[]::UUID[]`} 
+  ) RETURNING *
+    ),
   new_section_question AS (INSERT INTO section_question (section_id, question_id, list_order, required_if, show_if)
-  VALUES ({{payload.section_question.section_id}}, {{payload.section_question.question_id}}, 
+  SELECT {{payload.section_question.section_id}}, new_question.id, 
   {{payload.section_question.list_order}}, {{payload.section_question.required_if}}, 
-  {{payload.section_question.show_if}}) ON CONFLICT(section_id, question_id) DO UPDATE SET
+  {{payload.section_question.show_if}} FROM new_question ON CONFLICT(section_id, question_id) DO UPDATE SET
   section_id = EXCLUDED.section_id, question_id = EXCLUDED.question_id, list_order = EXCLUDED.list_order,
   required_if = EXCLUDED.required_if, show_if = EXCLUDED.show_if
   RETURNING *)

--- a/src/nodejs/lambda-layers/database-util/src/query/question.js
+++ b/src/nodejs/lambda-layers/database-util/src/query/question.js
@@ -133,8 +133,9 @@ const add = (params) => `
     ),
   new_section_question AS (INSERT INTO section_question (section_id, question_id, list_order, required_if, show_if)
   SELECT {{payload.section_question.section_id}}, new_question.id, 
-  {{payload.section_question.list_order}}, {{payload.section_question.required_if}}, 
-  {{payload.section_question.show_if}} FROM new_question ON CONFLICT(section_id, question_id) DO UPDATE SET
+  {{payload.section_question.list_order}}, ${params.payload.section_question.required_if ? `'${JSON.stringify(params.payload.section_question.required_if)}'::JSONB`: "'[]'::JSONB"}, 
+  ${params.payload.section_question.show_if ? `'${JSON.stringify(params.payload.section_question.show_if)}'::JSONB`: "'[]'::JSONB"}
+  FROM new_question ON CONFLICT(section_id, question_id) DO UPDATE SET
   section_id = EXCLUDED.section_id, question_id = EXCLUDED.question_id, list_order = EXCLUDED.list_order,
   required_if = EXCLUDED.required_if, show_if = EXCLUDED.show_if
   RETURNING *)

--- a/src/nodejs/lambda-layers/schema-util/src/models/index.js
+++ b/src/nodejs/lambda-layers/schema-util/src/models/index.js
@@ -22,6 +22,8 @@ const Page = require('./page.js');
 const Permission = require('./permission.js');
 const Question = require('./question.js');
 const QuestionList = require('./question-list.js');
+const QuestionAdd = require('./question-add.js');
+const QuestionInputs = require('./question-inputs.js');
 const Input = require('./input.js')
 const Role = require('./role.js');
 const Service = require('./service.js');
@@ -72,6 +74,8 @@ const models = {
   Permission,
   Question,
   QuestionList,
+  QuestionAdd,
+  QuestionInputs,
   Input,
   Role,
   Service,

--- a/src/nodejs/lambda-layers/schema-util/src/models/question-add.js
+++ b/src/nodejs/lambda-layers/schema-util/src/models/question-add.js
@@ -1,0 +1,50 @@
+module.exports.model = (path) => ({
+    description: 'Fields for adding a new question to the database',
+    type: 'object',
+    allOf: [{ $ref: `#${path}Question` }],
+    properties:{
+        section_question: {
+            type: 'object',
+            properties: {
+            section_id:  { $ref: `#${path}UUID` },
+            list_order: { type: 'number' },
+            required_if: {
+                type: 'array',
+                items: {
+                type: 'object',
+                properties: {
+                    field: { type: 'string' },
+                    value: { type: 'string' },
+                    message: { type: 'string' }
+                }
+                }
+            },
+            show_if: {
+                type: 'array',
+                items: {
+                type: 'object',
+                properties: {
+                    field: { type: 'string' },
+                    value: { type: 'string' },
+                    message: { type: 'string' }
+                }
+                }
+            }
+            },
+            required: [
+            'section_id',
+            'list_order'
+            ]
+        }
+    },
+    required: [
+        'short_name',
+        'long_name',
+        'text',
+        'help',
+        'section_question'
+    ]
+  });
+  
+  module.exports.refs = ['UUID'];
+  

--- a/src/nodejs/lambda-layers/schema-util/src/models/question-inputs.js
+++ b/src/nodejs/lambda-layers/schema-util/src/models/question-inputs.js
@@ -1,0 +1,13 @@
+module.exports.model = (path) => ({
+    description: 'A grouping of related inputs to be displayed on a form',
+    type: 'object',
+    allOf: [{ $ref: `#${path}Question` }],
+    properties:{
+      inputs: {
+        allOf: [{ $ref: `#${path}Input` }]
+      }
+    }
+  });
+  
+  module.exports.refs = ['UUID', 'Input', 'Question'];
+  

--- a/src/nodejs/lambda-layers/schema-util/src/models/question.js
+++ b/src/nodejs/lambda-layers/schema-util/src/models/question.js
@@ -3,48 +3,21 @@ module.exports.model = (path) => ({
   type: 'object',
   properties: {
     id: { $ref: `#${path}UUID` },
+    short_name: { type: 'string' },
     version: { type: 'number' },
-    question_name: { type: 'string' },
-    title: { type: 'string' },
+    long_name: { type: 'string'},
     text: { type: 'string' },
     help: { type: 'string' },
-    inputs: {
+    required: { type: 'boolean' },
+    created_at: { type: 'string'},
+    daac_ids: {
       type: 'array',
-      items: {
-        type: 'object',
-        properties: {
-          type: { type: 'string' },
-          id: { type: 'string' },
-          label: { type: 'string' },
-          required: { type: 'boolean' },
-          required_if: {
-            type: 'array',
-            items: {
-              type: 'object',
-              properties: {
-                field: { type: 'string' },
-                value: { type: 'string' },
-                message: { type: 'string' }
-              }
-            }
-          },
-          show_if: {
-            type: 'array',
-            items: {
-              type: 'object',
-              properties: {
-                field: { type: 'string' },
-                value: { type: 'string' },
-                message: { type: 'string' }
-              }
-            }
-          },
-          attributes: { type: 'object' },
-          enums: { type: 'array' }
+        items: {
+          $ref: `#${path}UUID`
         }
-      }
     }
   }
+
 });
 
 module.exports.refs = ['UUID'];

--- a/src/openapi/openapi.json
+++ b/src/openapi/openapi.json
@@ -2090,7 +2090,113 @@
         "x-router-controller": "cors"
       }
     },
-    "/api/data/question": {
+    "/api/data/questions": {
+      "get": {
+        "tags": [
+          "data"
+        ],
+        "summary": "Get questions",
+        "description": "Returns list of questions",
+        "operationId": "questionFindAll",
+        "parameters": [
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "What field to sort results on.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "description": "Order of results, 'asc' for ascending, 'desc' for descending.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
+          },
+          {
+            "name": "per_page",
+            "in": "query",
+            "description": "Number of results per page for pagination.",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number to start at for pagination.",
+            "schema": {
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Methods": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Headers": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Question"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Bad Request"
+          }
+        },
+        "security": [
+          {
+            "Cognito_Authorizer": ["openid"]
+          }
+        ],
+        "x-amazon-apigateway-integration": {
+          "uri": "${questions_lambda_arn}",
+          "passthroughBehavior": "when_no_match",
+          "httpMethod": "POST",
+          "type": "aws",
+          "requestTemplates": {
+            "application/json": "#set( $req = $input.params()) {\"resource\":\"question\",\"operation\":\"findAll\",\"params\":{#foreach($field in $req.querystring.keySet()) \"$field\":\"$req.querystring.get($field)\" #if($foreach.hasNext),#end #end},\"context\":{\"user_id\": \"$context.authorizer.claims.sub\", \"user_email\": \"$context.authorizer.claims.email\"}}"
+          },
+          "responses": {
+            "default": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+                "method.response.header.Access-Control-Allow-Methods": "'*'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key'"
+              }
+            }
+          }
+        },
+        "x-router-controller": "proxy"
+      },
       "post": {
         "tags": [
           "data"
@@ -11735,165 +11841,6 @@
           }
         },
         "x-router-controller": "proxy"
-      }
-    },
-    "/api/data/questions": {
-      "get": {
-        "tags": [
-          "data"
-        ],
-        "summary": "Get questions",
-        "description": "Returns list of questions",
-        "operationId": "questionFindAll",
-        "parameters": [
-          {
-            "name": "sort",
-            "in": "query",
-            "description": "What field to sort results on.",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "order",
-            "in": "query",
-            "description": "Order of results, 'asc' for ascending, 'desc' for descending.",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "asc",
-                "desc"
-              ]
-            }
-          },
-          {
-            "name": "per_page",
-            "in": "query",
-            "description": "Number of results per page for pagination.",
-            "schema": {
-              "type": "number"
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "Page number to start at for pagination.",
-            "schema": {
-              "type": "number"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Methods": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Headers": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Question"
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Bad Request"
-          }
-        },
-        "security": [
-          {
-            "Cognito_Authorizer": ["openid"]
-          }
-        ],
-        "x-amazon-apigateway-integration": {
-          "uri": "${questions_lambda_arn}",
-          "passthroughBehavior": "when_no_match",
-          "httpMethod": "POST",
-          "type": "aws",
-          "requestTemplates": {
-            "application/json": "#set( $req = $input.params()) {\"resource\":\"question\",\"operation\":\"findAll\",\"params\":{#foreach($field in $req.querystring.keySet()) \"$field\":\"$req.querystring.get($field)\" #if($foreach.hasNext),#end #end},\"context\":{\"user_id\": \"$context.authorizer.claims.sub\", \"user_email\": \"$context.authorizer.claims.email\"}}"
-          },
-          "responses": {
-            "default": {
-              "statusCode": "200",
-              "responseParameters": {
-                "method.response.header.Access-Control-Allow-Origin": "'*'",
-                "method.response.header.Access-Control-Allow-Methods": "'*'",
-                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key'"
-              }
-            }
-          }
-        },
-        "x-router-controller": "proxy"
-      },
-      "options": {
-        "tags": [
-          "cors"
-        ],
-        "summary": "CORS",
-        "description": "OPTIONS method for CORS",
-        "operationId": "optionsDataQuestions",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Methods": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Headers": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {}
-          }
-        },
-        "x-amazon-apigateway-integration": {
-          "type": "mock",
-          "requestTemplates": {
-            "application/json": "{\"statusCode\": 200 }"
-          },
-          "responses": {
-            "default": {
-              "statusCode": "200",
-              "responseParameters": {
-                "method.response.header.Access-Control-Allow-Origin": "'*'",
-                "method.response.header.Access-Control-Allow-Methods": "'*'",
-                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key'"
-              },
-              "responseTemplates": {
-                "application/json": "{}"
-              }
-            }
-          }
-        },
-        "x-router-controller": "cors"
       }
     },
     "/api/data/upload/getPostUrl": {

--- a/src/openapi/openapi.json
+++ b/src/openapi/openapi.json
@@ -2090,6 +2090,131 @@
         "x-router-controller": "cors"
       }
     },
+    "/api/data/question": {
+      "post": {
+        "tags": [
+          "data"
+        ],
+        "summary": "Creates a question",
+        "description": "Creates a new question.",
+        "operationId": "questionAdd",
+        "requestBody": {
+          "x-name": "payload",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QuestionAdd"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Methods": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Headers": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Question"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Cognito_Authorizer": ["openid"]
+          }
+        ],
+        "x-amazon-apigateway-integration": {
+          "uri": "${questions_lambda_arn}",
+          "passthroughBehavior": "when_no_match",
+          "httpMethod": "POST",
+          "type": "aws",
+          "requestTemplates": {
+            "application/json": "{\"resource\":\"question\",\"operation\":\"add\",\"params\":{\"payload\": $input.json(\"$\")},\"context\":{\"user_id\": \"$context.authorizer.claims.sub\"}}"
+          },
+          "responses": {
+            "default": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+                "method.response.header.Access-Control-Allow-Methods": "'*'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key'"
+              }
+            }
+          }
+        },
+        "x-router-controller": "proxy"
+      },
+      "options": {
+        "tags": [
+          "cors"
+        ],
+        "summary": "CORS",
+        "description": "OPTIONS method for CORS",
+        "operationId": "optionsDataQuestions",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Methods": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Headers": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {}
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "type": "mock",
+          "requestTemplates": {
+            "application/json": "{\"statusCode\": 200 }"
+          },
+          "responses": {
+            "default": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+                "method.response.header.Access-Control-Allow-Methods": "'*'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key'"
+              },
+              "responseTemplates": {
+                "application/json": "{}"
+              }
+            }
+          }
+        },
+        "x-router-controller": "cors"
+      }
+    },
     "/api/data/question/{id}": {
       "parameters": [
         {
@@ -2132,7 +2257,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Question"
+                  "$ref": "#/components/schemas/QuestionInputs"
                 }
               }
             }
@@ -11705,78 +11830,6 @@
           "type": "aws",
           "requestTemplates": {
             "application/json": "#set( $req = $input.params()) {\"resource\":\"question\",\"operation\":\"findAll\",\"params\":{#foreach($field in $req.querystring.keySet()) \"$field\":\"$req.querystring.get($field)\" #if($foreach.hasNext),#end #end},\"context\":{\"user_id\": \"$context.authorizer.claims.sub\", \"user_email\": \"$context.authorizer.claims.email\"}}"
-          },
-          "responses": {
-            "default": {
-              "statusCode": "200",
-              "responseParameters": {
-                "method.response.header.Access-Control-Allow-Origin": "'*'",
-                "method.response.header.Access-Control-Allow-Methods": "'*'",
-                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key'"
-              }
-            }
-          }
-        },
-        "x-router-controller": "proxy"
-      },
-      "post": {
-        "tags": [
-          "data"
-        ],
-        "summary": "Creates a question",
-        "description": "Creates a new question.",
-        "operationId": "questionAdd",
-        "requestBody": {
-          "x-name": "payload",
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Question"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "headers": {
-              "Access-Control-Allow-Origin": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Methods": {
-                "schema": {
-                  "type": "string"
-                }
-              },
-              "Access-Control-Allow-Headers": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "Cognito_Authorizer": ["openid"]
-          }
-        ],
-        "x-amazon-apigateway-integration": {
-          "uri": "${questions_lambda_arn}",
-          "passthroughBehavior": "when_no_match",
-          "httpMethod": "POST",
-          "type": "aws",
-          "requestTemplates": {
-            "application/json": "{\"resource\":\"question\",\"operation\":\"add\",\"params\":{\"payload\": $input.json(\"$\")},\"context\":{\"user_id\": \"$context.authorizer.claims.sub\"}}"
           },
           "responses": {
             "default": {


### PR DESCRIPTION

# Description

This fixes the endpoint for adding a question via the api.

## Spec

See Ticket: https://bugs.earthdata.nasa.gov/browse/EDPUB-1395

---

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Log into the dashboard and retrieve a bearer token
4. Navigate to the swagger and authorize the page with the bearer token from 3
5. Scroll down to the /api/data/question endpoint
6. Click try me out and enter a test question matching the provided schema. I.E.
```
{
  "version": 1,
  "short_name": "test",
  "long_name": "TEST CASE",
  "text": "string",
  "help": "someone help me",
  "required": true,
  "daac_ids": ["15df4fda-ed0d-417f-9124-558fb5e5b561"],
  "section_question": {
    "section_id": "049e63e8-018d-4c3f-96f1-80c73e0f4287",
    "list_order": 0,
    "required_if": [],
    "show_if": []
  }
}
```
7. Verify that the question was added to the questions and section_question tables.

---

## Change Log

* Fixes the add question endpoint