### PR TITLE
EDPUB-1412: Remove Confirmation Form from ASDC Workflow

### DIFF
--- a/src/postgres/7-seed.sql
+++ b/src/postgres/7-seed.sql
@@ -607,8 +607,7 @@ INSERT INTO step_edge VALUES ('a8d22c43-7814-4609-ac04-66fb50228bf7', 'init', 'd
 INSERT INTO step_edge VALUES ('a8d22c43-7814-4609-ac04-66fb50228bf7', 'data_accession_request_form', 'data_accession_request_form_review');
 INSERT INTO step_edge VALUES ('a8d22c43-7814-4609-ac04-66fb50228bf7', 'data_accession_request_form_review', 'data_publication_request_form');
 INSERT INTO step_edge VALUES ('a8d22c43-7814-4609-ac04-66fb50228bf7', 'data_publication_request_form', 'data_publication_request_form_review');
-INSERT INTO step_edge VALUES ('a8d22c43-7814-4609-ac04-66fb50228bf7', 'data_publication_request_form_review', 'confirmation_form');
-INSERT INTO step_edge VALUES ('a8d22c43-7814-4609-ac04-66fb50228bf7', 'confirmation_form', 'email_asdc_staff');
+INSERT INTO step_edge VALUES ('a8d22c43-7814-4609-ac04-66fb50228bf7', 'data_publication_request_form_review', 'email_asdc_staff');
 INSERT INTO step_edge VALUES ('a8d22c43-7814-4609-ac04-66fb50228bf7', 'email_asdc_staff', 'close');
 
 INSERT INTO step_edge VALUES ('c651b698-ec06-44d7-a69b-44bf8b4bc4f5', 'init', 'close');

--- a/src/postgres/9-updates.sql
+++ b/src/postgres/9-updates.sql
@@ -116,3 +116,15 @@ WHERE privilege = 'FORM_CREATE' AND edprole_id IN ('a5b4947a-67d2-434e-9889-59c2
 
 -- The FORM_CREATE privilege should only be assigned to DAAC Data Managers.
 INSERT INTO edprole_privilege VALUES ('2aa89c57-85f1-4611-812d-b6760bb6295c', 'FORM_CREATE');
+
+-- EDPUB-1412: Remove Confirmation Form from ASDC Workflow
+DELETE FROM step_edge
+WHERE workflow_id = 'a8d22c43-7814-4609-ac04-66fb50228bf7'
+  AND step_name = 'confirmation_form'
+  AND next_step_name = 'email_asdc_staff';
+
+UPDATE step_edge
+SET next_step_name = 'email_asdc_staff'
+WHERE workflow_id = 'a8d22c43-7814-4609-ac04-66fb50228bf7'
+  AND step_name = 'data_publication_request_form_review'
+  AND next_step_name = 'confirmation_form';


### PR DESCRIPTION
# Description

Remove Confirmation Form from ASDC Workflow
Description: ASDC no longer needs the confirmation form. It should be removed from their workflow and the step should be removed from the database. Extra attention should be made when this change makes it through the environments to be sure that no existing submission is in the confirmation form step of the workflow.



## Spec


See Ticket: [EDPUB-1412](https://bugs.earthdata.nasa.gov/browse/EDPUB-1412)

---

## Validation

1. Make sure you run all the SQL queries in updates.sql
2. When deployed in higher env's make sure we follow the below
" Extra attention should be made when this change makes it through the environments to be sure that no existing submission is in the confirmation form step of the workflow"