### PR TITLE
EDPUB-1436: Create DAAC Backfill Publication Codes

### DIFF
--- a/src/postgres/2-tables.sql
+++ b/src/postgres/2-tables.sql
@@ -633,7 +633,7 @@ CREATE TABLE IF NOT EXISTS note_scope (
 
 CREATE TABLE IF NOT EXISTS code (
   code UUID DEFAULT UUID_GENERATE_V4(),
-  submission_id UUID NOT NULL,
+  submission_id UUID,
   daac_id UUID NOT NULL,
   PRIMARY KEY (code),
   FOREIGN KEY (submission_id) REFERENCES submission (id),

--- a/src/postgres/9-updates.sql
+++ b/src/postgres/9-updates.sql
@@ -149,3 +149,24 @@ INSERT INTO section_question VALUES ('768a6b51-4864-458c-b20d-fb8b4c7dc606', 'ad
 
 -- 11/15/24 Add attachments column to notes and add default
 ALTER TABLE note ADD attachments VARCHAR[] DEFAULT '{}';
+
+-- 12/09/24 EDPUB-1436 Create DAAC Backfill Publication Codes
+ALTER TABLE code
+ALTER COLUMN submission_id DROP NOT NULL;
+
+-- Bulk insert daac_id to code table
+INSERT INTO code (daac_id) VALUES 
+('40397fe8-4841-4e4c-b84a-6ece359ff5ff'),
+('c606afba-725b-4ae4-9557-1fd33260ae12'),
+('d551380f-8813-40e4-9763-2a5bb6007cd0'),
+('1ea1da68-cb95-431f-8dd8-a2cf16d7ef98'),
+('ef229725-1cad-485e-a72b-a276d2ca3175'),
+('9e0628f1-0dde-4ed2-b1e3-690c70326f25'),
+('de6d5ec9-4728-4f2b-9d43-ae2f0fdac96a'),
+('aec3724f-b30b-4b3f-9b9a-e0907d9d14b3'),
+('fe75c306-ac04-4689-a702-073d9cb071fe'),
+('15df4fda-ed0d-417f-9124-558fb5e5b561'),
+('6b3ea184-57c5-4fc5-a91b-e49708f91b67'),
+('00dcf32a-a4e2-4e55-a0d1-3a74cf100ca1'),
+('cdccdd71-cbe2-4220-8569-a6355ea24f3f'),
+('1c36f0b9-b7fd-481b-9cab-3bc3cea35413');


### PR DESCRIPTION
# Description

DAACs will be provided backfill publication codes to accommodate publishing data products which have already been approved and assigned outside of EDPub. This task will be manually seed these code into the EDPub SIT/UAT/PROD instances as well as document them internally for later distribution.



## Spec


See Ticket: [EDPUB-1436](https://bugs.earthdata.nasa.gov/browse/EDPUB-1436)

---

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Navigate to the code table and check if the rows are inserted with all the daac_ids after running the update and insert query. 

