### PR TITLE
Edpub-1444: Add Draft Attachments Cleanup

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -53,6 +53,7 @@ install_lambda questions
 install_lambda workflow
 install_lambda file-upload
 install_lambda mfa-auth
+install lamdba draft-cleanup
 #Add more lambda functions here <--
 
 #Change back to root directory and remove temp folder

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -53,7 +53,7 @@ install_lambda questions
 install_lambda workflow
 install_lambda file-upload
 install_lambda mfa-auth
-install_lamdba draft-cleanup
+install_lambda draft-cleanup
 #Add more lambda functions here <--
 
 #Change back to root directory and remove temp folder

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -53,7 +53,7 @@ install_lambda questions
 install_lambda workflow
 install_lambda file-upload
 install_lambda mfa-auth
-install lamdba draft-cleanup
+install_lamdba draft-cleanup
 #Add more lambda functions here <--
 
 #Change back to root directory and remove temp folder

--- a/src/nodejs/controllers/handlers.js
+++ b/src/nodejs/controllers/handlers.js
@@ -21,3 +21,4 @@ module.exports.rdsBackup = require('../lambda-handlers/rds-backup').handler;
 module.exports.workflow = require('../lambda-handlers/workflow.js').handler;
 module.exports.fileUpload = require('../lambda-handlers/file-upload.js').handler;
 module.exports.form = require('../lambda-handlers/form.js').handler;
+module.exports.form = require('../lambda-handlers/draft-cleanup.js').handler;

--- a/src/nodejs/lambda-handlers/draft-cleanup.js
+++ b/src/nodejs/lambda-handlers/draft-cleanup.js
@@ -1,0 +1,42 @@
+const { S3Client, PutBucketLifecycleConfigurationCommand } = require('@aws-sdk/client-s3');
+
+const ingestBucket = process.env.INGEST_BUCKET;
+const region = process.env.REGION;
+const s3Client = new S3Client({ region });
+
+// Define the bucket name and lifecycle configuration
+const lifecycleConfiguration = {
+  Rules: [
+    {
+      ID: 'CleanupDrafts',
+      Filter: {
+        Prefix: 'drafts/'
+      },
+      Status: 'Enabled',
+      Expiration: {
+        Days: 7
+      }
+    }
+  ]
+};
+
+// Function to set the lifecycle policy
+async function setLifecyclePolicy() {
+  try {
+    const command = new PutBucketLifecycleConfigurationCommand({
+      Bucket: ingestBucket,
+      LifecycleConfiguration: { Rules: lifecycleConfiguration.Rules }
+    });
+
+    await s3Client.send(command);
+  } catch (error) {
+    console.error('Error setting lifecycle policy:', error);
+  }
+}
+
+async function handler() {
+  await setLifecyclePolicy();
+  return { statusCode: 200 };
+}
+
+module.exports.handler = handler;

--- a/terraform/lambda/main.tf
+++ b/terraform/lambda/main.tf
@@ -1142,3 +1142,25 @@ resource "aws_lambda_permission" "mfa_auth" {
   principal     = "apigateway.amazonaws.com"
   source_arn    = "arn:aws:execute-api:${var.region}:${var.account_id}:${var.api_id}/*/*/mfa/*"
 }
+
+# DraftCleanup Lambda
+resource "aws_lambda_function" "draft_cleanup" {
+  filename         = "../artifacts/draft-cleanup-lambda.zip"
+  function_name    = "remap_statics"
+  role             = var.edpub_lambda_role_arn
+  handler          = "draft-cleanup.handler"
+  layers           = []
+  runtime          = "nodejs18.x"
+  source_code_hash = filesha256("../artifacts/draft-cleanup-lambda.zip")
+  timeout          = 180
+  environment {
+    variables = {
+      REGION           = var.region
+      INGEST_BUCKET    = var.edpub_upload_s3_bucket
+    }
+  }
+  vpc_config {
+    subnet_ids         = var.subnet_ids
+    security_group_ids = var.security_group_ids
+  }
+}

--- a/terraform/lambda/main.tf
+++ b/terraform/lambda/main.tf
@@ -1144,9 +1144,10 @@ resource "aws_lambda_permission" "mfa_auth" {
 }
 
 # DraftCleanup Lambda
+
 resource "aws_lambda_function" "draft_cleanup" {
   filename         = "../artifacts/draft-cleanup-lambda.zip"
-  function_name    = "remap_statics"
+  function_name    = "draft_cleanup"
   role             = var.edpub_lambda_role_arn
   handler          = "draft-cleanup.handler"
   layers           = []


### PR DESCRIPTION
# Description

Attachments are first uploaded to a draft s3 location. Once the note is sent, they are moved to a final location. If a draft is uploaded but the note not sent, the draft attachment will remain in s3. This task aims to add a mechanism (cron / lifecycle policy / etc) for cleaning up those attachments


## Spec


See Ticket: [EDPUB-1444](https://bugs.earthdata.nasa.gov/browse/EDPUB-1444)

---

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. make sure the lifecycle is added to the AWS account. 

_