### PR TITLE
EDPUB-1444: Add Draft Attachments Cleanup

### DIFF
--- a/terraform/s3/main.tf
+++ b/terraform/s3/main.tf
@@ -17,6 +17,16 @@ resource "aws_s3_bucket" "earthdatapub-upload" {
       days = 14
     }
   }
+
+  lifecycle_rule {
+    id      = "draft-attachments-age-off"
+    prefix  = "drafts/"
+    enabled = true
+
+    expiration {
+      days = 7
+    }
+  }
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "upload-encryption" {


### PR DESCRIPTION
# Description

Same as https://github.com/eosdis-nasa/earthdata-pub-api/pull/170 but using terraform.

Ages off draft attachments which have been uploaded but not sent as part of a note reply.

---
