### PR TITLE
Edpub 1433 code generation and notification

### DIFF
--- a/src/nodejs/controllers/proxy.js
+++ b/src/nodejs/controllers/proxy.js
@@ -944,6 +944,19 @@ module.exports.submissionOperationMapMetadata = function submissionOperationMapM
   });
 };
 
+module.exports.submissionOperationAssignDaacs = function submissionOperationAssignDaacs(req, res, next) {
+  const { params } = req.swagger;
+  const { payload } = params;
+  const lambdaEvent = {
+    operation: 'assignDaacs',
+    context: { user_id: req.user_id },
+    ...payload.value
+  };
+  handlers.submission(lambdaEvent).then((body) => {
+    setTimeout(() => res.send(body), latency);
+  });
+};
+
 module.exports.searchMetrics = function searchMetrics(req, res, next) {
   const { params } = req.swagger;
   const lambdaEvent = {

--- a/src/nodejs/lambda-handlers/submission.js
+++ b/src/nodejs/lambda-handlers/submission.js
@@ -417,7 +417,7 @@ async function assignDaacsMethod(event, user) {
   let submission = await db.submission.findById({ id });
 
   // Check current step - only proceed if on DAAC assignment step
-  if (submission.step_name !== 'daac_assignment'){
+  if (submission.step_name !== 'daac_assignment') {
     return { error: 'Invalid workflow step. Unable to assign DAACs.' };
   }
 

--- a/src/nodejs/lambda-handlers/submission.js
+++ b/src/nodejs/lambda-handlers/submission.js
@@ -414,13 +414,20 @@ async function assignDaacsMethod(event, user) {
     return { error: 'Invalid permissions.' };
   }
 
+  let submission = await db.submission.findById({ id });
+
+  // Check current step - only proceed if on DAAC assignment step
+  if (submission.step_name !== 'daac_assignment'){
+    return { error: 'Invalid workflow step. Unable to assign DAACs.' };
+  }
+
   // Generate a code for each daac to be assigned
   // eslint-disable-next-line
   for (const daacId of daacs) {
     await db.submission.createCode({ submissionId: id, daacID: daacId });
   }
 
-  const submission = await db.submission.findById({ id });
+  submission = await db.submission.findById({ id });
 
   // Send notification emails to the following
   // - the point of contact of the submission (form response),

--- a/src/nodejs/lambda-layers/database-util/src/query/parsers.js
+++ b/src/nodejs/lambda-layers/database-util/src/query/parsers.js
@@ -92,6 +92,7 @@ module.exports.onboard = one;
 module.exports.offboard = one;
 module.exports.getSubmissionDaac = one;
 module.exports.getManagerIds = many;
+module.exports.getObserverIds = many;
 module.exports.getStepReviewApproval = many;
 module.exports.createStepReviewApproval = many;
 module.exports.deleteStepReviewApproval = many;

--- a/src/nodejs/lambda-layers/database-util/src/query/user.js
+++ b/src/nodejs/lambda-layers/database-util/src/query/user.js
@@ -426,6 +426,23 @@ const getManagerIds = (params) => sql.select({
   }
 });
 
+const getObserverIds = (params) => sql.select({
+  fields: ['id'],
+  from: {
+    base: 'edpuser',
+    joins:[
+      {type: 'left_join', src: 'edpuser_edprole', on: {left: 'edpuser_edprole.edpuser_id', right: 'edpuser.id'}}
+    ]
+  },
+  where: {
+    filters: [
+      { field: 'edpuser.id', any: { values: { param: 'contributor_ids' } } },
+      { cmd: "edpuser_edprole.edprole_id = '4be6ca4d-6362-478b-8478-487a668314b1'"}
+
+    ]
+  }
+});
+
 
 module.exports.find = find;
 module.exports.findAll = findAll;
@@ -448,3 +465,4 @@ module.exports.getUsers = getUsers;
 module.exports.setDetail = setDetail;
 module.exports.updateUsername = updateUsername;
 module.exports.getManagerIds = getManagerIds;
+module.exports.getObserverIds = getObserverIds;

--- a/src/nodejs/lambda-layers/message-util/src/create-email.js
+++ b/src/nodejs/lambda-layers/message-util/src/create-email.js
@@ -3,6 +3,7 @@ const { getNewSubmissionTemplate } = require('./templates/new-submission');
 const { getNewSubmissionDAACTemplate } = require('./templates/new-submission-daac');
 const { getDMTemplate } = require('./templates/direct-message');
 const { getReviewerAddedTemplate } = require('./templates/review-template');
+const { getAssignedDaacCodeTemplate } = require('./templates/assigned-daac-codes.js');
 
 const envUrl = process.env.ROOT_URL;
 
@@ -17,6 +18,8 @@ const createEmailHtml = async (params) => {
       ? getNewSubmissionTemplate(params, envUrl) : getNewSubmissionDAACTemplate(params, envUrl));
   } if (params.eventMessage.event_type === 'review_required') {
     return getReviewerAddedTemplate(params, envUrl);
+  } if (params.eventMessage.event_type === 'daac_assignment') {
+    return getAssignedDaacCodeTemplate(params, envUrl);
   }
   return getDefaultStepPromotion(params, envUrl);
 };

--- a/src/nodejs/lambda-layers/message-util/src/templates/assigned-daac-codes.js
+++ b/src/nodejs/lambda-layers/message-util/src/templates/assigned-daac-codes.js
@@ -1,0 +1,33 @@
+const getAssignedDaacCodeTemplate = (params, envUrl) => {
+  const { user, eventMessage } = params;
+  const text = `Hello ${user.name},\n\nThe ${eventMessage.submission_name} accession request has been assigned to the following DAAC(s) with the corresponding publication token(s):\n\n${eventMessage.assigned_daacs.map((element) => `${element.daac_name}: ${element.code}`).join('\n')}\n\nThese tokens can now be used to initiate a new publication request for the corresponding DAAC which will begin the publication workflow for the assigned DAAC.`;
+  const html = `
+    <html>
+    <body>
+        <style>td h1 { margin: 0; padding: 0; font-size: 22px; }</style>
+        <table border="0" cellpadding="10" cellspacing="0" style="width:100%">
+            <tr style="width:100%;background:#f8f8f8">
+                <td><table><tr>
+                    <td width="60"><img src="https://pub.earthdata.nasa.gov/dashboard/images/app/src/assets/images/nasa-logo.78fcba4d9325e8ac5a2e15699d035ee0.svg"></td>
+                    <td><h4>Earthdata Pub</h4></td>
+                </tr></table></td>
+                <td align="right"><b>Code Distribution</b></td>
+                <td></td>
+            </tr>
+            <tr>
+                <td colspan="2" style="padding:20px;">
+                    <h1>Hello ${user.name},</h1><br>
+                    <br>
+                    <p>The ${eventMessage.submission_name} accession request has been assigned to the following DAAC(s) with the corresponding publication token(s):</p>
+                    ${eventMessage.assigned_daacs.map((element) => `<p>${element.daac_name}: ${element.code}</p>`).join('\n')}
+                    <p>These tokens can now be used to initiate a new publication request for the corresponding DAAC which will begin the publication workflow for the assigned DAAC.</p>
+                    <p><a style="text-align: left;" href="${envUrl}/dashboard" aria-label="Visit Earthdata Pub Dashboard">${envUrl}/dashboard</a></p>
+                </td>
+            </tr>
+        </table>
+    </body>
+    </html> 
+    `;
+  return [text, html];
+};
+module.exports.getAssignedDaacCodeTemplate = getAssignedDaacCodeTemplate;

--- a/src/nodejs/lambda-layers/schema-util/src/models/index.js
+++ b/src/nodejs/lambda-layers/schema-util/src/models/index.js
@@ -31,6 +31,7 @@ const StepReviewCreateDelete = require('./stepreview-create-delete.js')
 const Submission = require('./submission.js');
 const SubmissionOperationMapMetadata = require('./submission-operation-map-metadata.js');
 const SubmissionOperationRequest = require('./submission-operation-request.js');
+const SubmissionOperationAssignDaacs = require('./submission-operation-assign-daacs.js');
 const SubscribeRequest = require('./subscribe-request.js');
 const Subscription = require('./subscription.js');
 const User = require('./user.js');
@@ -86,6 +87,7 @@ const models = {
   SubmissionOperationMapMetadata,
   SubmissionOperationRequest,
   SubscribeRequest,
+  SubmissionOperationAssignDaacs,
   Subscription,
   User,
   UUID,

--- a/src/nodejs/lambda-layers/schema-util/src/models/submission-operation-assign-daacs.js
+++ b/src/nodejs/lambda-layers/schema-util/src/models/submission-operation-assign-daacs.js
@@ -1,0 +1,17 @@
+module.exports.model = (path) => ({
+  description: 'Assign one or more DAACs to a submission',
+  type: 'object',
+  properties: {
+      id: {
+        description: 'UUID of the Submission to assign DAACS',
+        $ref: `#${path}UUID`
+      },
+      daacs: {
+          description: 'List of UUIDs of DAACs to assign',
+          type: 'array',
+          items: { $ref: `#${path}UUID` }
+        }
+  }
+});
+
+module.exports.refs = ['UUID'];

--- a/src/openapi/openapi.json
+++ b/src/openapi/openapi.json
@@ -6306,6 +6306,124 @@
         "x-router-controller": "cors"
       }
     },
+    "/api/data/submission/operation/assignDaacs": {
+      "post": {
+        "tags": [
+          "data"
+        ],
+        "summary": "Assignes one or more DAACs to a submission.",
+        "description": "Assigns one or more DAACs and generates the associated codes for a submission",
+        "operationId": "submissionOperationAssignDaacs",
+        "requestBody": {
+          "x-name": "payload",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubmissionOperationAssignDaacs"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Methods": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Headers": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Cognito_Authorizer": ["openid"]
+          }
+        ],
+        "x-amazon-apigateway-integration": {
+          "uri": "${submission_lambda_arn}",
+          "passthroughBehavior": "when_no_match",
+          "httpMethod": "POST",
+          "type": "aws",
+          "requestTemplates": {
+            "application/json": "#set($req = $input.params()) #set($body = $util.parseJson($input.body)) #set($inputRoot = $input.path('$')) {\"operation\":\"assignDaacs\", #if($body.containsKey('id'))\"id\":\"$body.get('id')\",#end #if($body.containsKey('daacs'))\"daacs\": $inputRoot.daacs,#end \"context\":{\"user_id\":\"$context.authorizer.claims.sub\", \"user_email\": \"$context.authorizer.claims.email\"}}"
+          },
+          "responses": {
+            "default": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+                "method.response.header.Access-Control-Allow-Methods": "'*'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key'"
+              }
+            }
+          }
+        },
+        "x-router-controller": "proxy"
+      },
+      "options": {
+        "tags": [
+          "cors"
+        ],
+        "summary": "CORS",
+        "description": "OPTIONS method for CORS",
+        "operationId": "optionsSubmission",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Methods": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Headers": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {}
+          }
+        },
+        "x-amazon-apigateway-integration": {
+          "type": "mock",
+          "requestTemplates": {
+            "application/json": "{\"statusCode\": 200 }"
+          },
+          "responses": {
+            "default": {
+              "statusCode": "200",
+              "responseParameters": {
+                "method.response.header.Access-Control-Allow-Origin": "'*'",
+                "method.response.header.Access-Control-Allow-Methods": "'*'",
+                "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key'"
+              },
+              "responseTemplates": {
+                "application/json": "{}"
+              }
+            }
+          }
+        },
+        "x-router-controller": "cors"
+      }
+    },
     "/api/data/submission/{id}/details": {
       "parameters": [
         {

--- a/src/postgres/7-seed.sql
+++ b/src/postgres/7-seed.sql
@@ -345,6 +345,7 @@ INSERT INTO privilege VALUES ('REQUEST_LOCK');
 INSERT INTO privilege VALUES ('REQUEST_UNLOCK');
 INSERT INTO privilege VALUES ('REQUEST_ADDUSER');
 INSERT INTO privilege VALUES ('REQUEST_REMOVEUSER');
+INSERT INTO privilege VALUES ('REQUEST_ASSIGNDAAC');
 
 INSERT INTO privilege VALUES ('USER_CREATE');
 INSERT INTO privilege VALUES ('USER_READ');
@@ -464,6 +465,8 @@ INSERT INTO edprole_privilege VALUES ('4be6ca4d-6362-478b-8478-487a668314b1', 'N
 INSERT INTO edprole_privilege VALUES ('4be6ca4d-6362-478b-8478-487a668314b1', 'NOTE_REPLY');
 INSERT INTO edprole_privilege VALUES ('4be6ca4d-6362-478b-8478-487a668314b1', 'NOTE_ADDUSER');
 INSERT INTO edprole_privilege VALUES ('4be6ca4d-6362-478b-8478-487a668314b1', 'NOTE_REMOVEUSER');
+INSERT INTO edprole_privilege VALUES ('4be6ca4d-6362-478b-8478-487a668314b1', 'REQUEST_ASSIGNDAAC');
+
 
 -- UserRole(edpuser_id, edprole_id)
 INSERT INTO edpuser_edprole VALUES ('1b10a09d-d342-4eee-a9eb-c99acd2dde17', '75605ac9-bf65-4dec-8458-93e018dcca97');
@@ -503,12 +506,15 @@ INSERT INTO step(step_name, type, data) VALUES ('get_from_mmt', 'action', '{"rol
 INSERT INTO step(step_name, type, data) VALUES ('map_from_mmt', 'action', '{"rollback":"get_from_mmt","type": "action"}');
 INSERT INTO step(step_name, type, data) VALUES ('publish_to_cmr', 'action', '{"rollback":"map_from_mmt","type": "action"}');
 INSERT INTO step(step_name, type, action_id) VALUES ('send_to_mmt', 'action', '3fe93672-cd91-45d4-863b-c6d0d63f8c8c');
+INSERT INTO step(step_name, type, data) VALUES ('daac_assignment', 'action', '{"rollback":"data_accession_request_form_review","type": "review"}');
 
 -- Unknown DAAC
 -- StepEdge(workflow_id, step_name, next_step_name)
 INSERT INTO step_edge VALUES ('3335970e-8a9b-481b-85b7-dfaaa3f5dbd9', 'init', 'data_accession_request_form');
 INSERT INTO step_edge VALUES ('3335970e-8a9b-481b-85b7-dfaaa3f5dbd9', 'data_accession_request_form', 'data_accession_request_form_review');
-INSERT INTO step_edge VALUES ('3335970e-8a9b-481b-85b7-dfaaa3f5dbd9', 'data_accession_request_form_review', 'assign_a_workflow');
+INSERT INTO step_edge VALUES ('3335970e-8a9b-481b-85b7-dfaaa3f5dbd9', 'data_accession_request_form_review', 'daac_assignment');
+INSERT INTO step_edge VALUES ('3335970e-8a9b-481b-85b7-dfaaa3f5dbd9', 'daac_assignment', 'close');
+
 
 -- GHRC
 -- Step(step_name, type, action_id, form_id, service_id, data)
@@ -645,5 +651,3 @@ INSERT INTO daac VALUES ('15df4fda-ed0d-417f-9124-558fb5e5b561', 'ORNL DAAC', 'O
 INSERT INTO daac VALUES ('6b3ea184-57c5-4fc5-a91b-e49708f91b67', 'PO.DAAC', 'Physical Oceanography Distributed Active Archive Center (PO.DAAC)', 'http://podaac.jpl.nasa.gov/', 'NASA''s Physical Oceanography Distributed Active Archive Center (PO.DAAC) is located at NASA''s Jet Propulsion Laboratory in Pasadena, California. PO.DAAC manages and provides tools and services for NASA''s oceanographic and hydrologic data (satellite, airborne, and in-situ) to enable greater understanding of the physical processes and condition of the global ocean. Measurements include gravity, ocean winds, sea surface temperature, ocean surface topography, sea surface salinity, ocean currents, and circulation. The data support a wide range of applications including climate research, weather prediction, resource management, policy, and the stewardship of ocean data resources. Sample data holdings include Aquarius, Soil Moisture Active Passive (SMAP), Gravity Recovery and Climate Experiment(GRACE), GRACE Follow-on (GRACE-FO), NASA Scatterometer (NSCAT), Quick Scatterometer (QuikSCAT), Rapid Scatterometer (RapidScat), Cyclone Global Navigation Satellite System (CYGNSS), TOPEX/POSEIDON, Jason-1, Group for High Resolution Sea Surface Temperature (GHRSST), Oceans Melting Greenland (OMG), Salinity Processes in the Upper Ocean Regional Study (SPURS), and Making Earth System Data Records for Use in Research Environments (MEaSUREs). Data access services include PO.DAAC Drive, Thematic Real-time Environmental Distributed Data Services (THREDDS), Open-source Project for a Network Data Access Protocol (OPeNDAP), PO.DAAC Web Services, and PO.DAAC GitHub repository. Tools that provide subsetting, extraction, and visualization capabilities include High-level Tool for Interactive Data Extraction (HiTIDE), Live Access Server (LAS), and State of the Ocean (SOTO).', 'Gravity, Ocean Circulation, Ocean Heat Budget, Ocean Surface Topography, Ocean Temperature, Ocean Waves, Ocean Winds, Ocean Salinity, Surface Water', 'a5a14d98-df13-47f2-b86b-1504c7d4360d', 'e847900e-90e2-47f8-85c6-94e06bcbcca0','false');
 INSERT INTO daac VALUES ('00dcf32a-a4e2-4e55-a0d1-3a74cf100ca1', 'SEDAC', 'Socioeconomic Data and Applications Data Center (SEDAC)', 'http://sedac.ciesin.columbia.edu/', 'NASA''s Socioeconomic Data and Applications Center (SEDAC) is operated by the Center for International Earth Science Information Network (CIESIN), a unit of the Earth Institute at Columbia University based at the Lamont-Doherty Earth Observatory in Palisades, New York. SEDAC''s missions are to synthesize Earth science and socioeconomic data and information in ways useful to a wide range of decision makers and other applied users, and to provide an “Information Gateway” between the socioeconomic and Earth science data and information domains. SEDAC datasets can be accessed via the dataset section of the SEDAC web site.', 'Synthesized Earth science and socio-economic data', 'c1690729-b67e-4675-a1a5-b2323f347dff', 'f0a89bc6-707f-4a34-8041-1593934c2e42','true');
 INSERT INTO daac VALUES ('cdccdd71-cbe2-4220-8569-a6355ea24f3f', 'Example', 'Example DAAC', 'https://earthdata.nasa.gov', 'This is an example DAAC for sample and testing purposes.', 'Testing of EDPUB', 'c1690729-b67e-4675-a1a5-b2323f347dff', '8edd07a0-34e1-45c7-a2c1-7fc9ae884030','false');
-INSERT INTO daac VALUES ('1c36f0b9-b7fd-481b-9cab-3bc3cea35413', 'Unknown', 'Unknown DAAC', 'https://earthdata.nasa.gov', 'Choose this if you are not sure where the data product should be archived.', '', '3335970e-8a9b-481b-85b7-dfaaa3f5dbd9', '5be24b44-d66b-4396-9266-a9d066000d9e','false');
-

--- a/src/postgres/9-updates.sql
+++ b/src/postgres/9-updates.sql
@@ -184,3 +184,11 @@ DELETE FROM step_edge WHERE workflow_id='c1690729-b67e-4675-a1a5-b2323f347dff' A
 UPDATE step_edge SET next_step_name='data_publication_request_form' WHERE workflow_id='a5a14d98-df13-47f2-b86b-1504c7d4360d' AND step_name='init';
 DELETE FROM step_edge WHERE workflow_id='a5a14d98-df13-47f2-b86b-1504c7d4360d' AND step_name='data_accession_request_form';
 DELETE FROM step_edge WHERE workflow_id='a5a14d98-df13-47f2-b86b-1504c7d4360d' AND step_name='data_accession_request_form_review';
+
+-- 1/3/25 Update dashboard to handle DAAC Assginment
+INSERT INTO step(step_name, type, data) VALUES ('daac_assignment', 'action', '{"rollback":"data_accession_request_form_review","type": "review"}');
+UPDATE step_edge SET next_step_name='daac_assignment' WHERE workflow_id='3335970e-8a9b-481b-85b7-dfaaa3f5dbd9' AND step_name='data_accession_request_form_review';
+INSERT INTO step_edge VALUES ('3335970e-8a9b-481b-85b7-dfaaa3f5dbd9', 'daac_assignment', 'close');
+INSERT INTO privilege VALUES ('REQUEST_ASSIGNDAAC');
+INSERT INTO edprole_privilege VALUES ('4be6ca4d-6362-478b-8478-487a668314b1', 'REQUEST_ASSIGNDAAC');
+DELETE FROM daac WHERE id='1c36f0b9-b7fd-481b-9cab-3bc3cea35413';

--- a/terraform/lambda/main.tf
+++ b/terraform/lambda/main.tf
@@ -711,6 +711,7 @@ resource "aws_lambda_function" "submission" {
       PG_PASS        = var.db_password
       PG_PORT        = var.db_port
       SOURCE_EMAIL   = var.ses_from_email
+      ROOT_URL       = var.client_root_url
     }
   }
   vpc_config {


### PR DESCRIPTION
# Description

Adds backend code for DAAC assignment. Creates codes for each assigned DAAC, emails relevant parties, and promotes the step

## Spec

See Ticket: https://bugs.earthdata.nasa.gov/browse/EDPUB-1433

Pre-requisits:
- https://github.com/eosdis-nasa/earthdata-pub-api/pull/171 : Needed to create a request with the Accession Workflow

---

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches to SIT
3. Log into dashboard
4. Click New Request -> Data Accession Request Submission
5. Move the request ahead to the daac_assignment workflow step.
6. Call the `/api/data/submission/operation/assignDaacs` endpoint with the request id for the DAR and a daac to assign to it. I.E.
```
{
  "id": "3ff7b912-950b-4bcd-8118-a913e4632ba6",
  "daacs": [
    "1ea1da68-cb95-431f-8dd8-a2cf16d7ef98"
  ]
}
```
7. Verify that the returned object lists the assigned DAAC and that an email was received with the assigned code.
```
"assigned_daacs": [
    {
      "code": "4bc6d61a-11dc-4c5f-babb-b4af4dde574b",
      "daac_id": "1ea1da68-cb95-431f-8dd8-a2cf16d7ef98",
      "daac_name": "GES DISC"
    }
  ],
```

---

## Change Log

* Adds backend for daac assignment and notification