### PR TITLE
Edpub 1456 add ses configuration to terraform

### DIFF
--- a/terraform/aws_secrets/main.tf
+++ b/terraform/aws_secrets/main.tf
@@ -7,8 +7,8 @@ resource "aws_secretsmanager_secret" "ses_access_creds" {
 resource "aws_secretsmanager_secret_version" "ses_access_creds" {
   secret_id = aws_secretsmanager_secret.ses_access_creds.id
     secret_string = jsonencode({
-        "ses_access_key_id" = var.ses_access_key_id
-        "ses_secret_access_key" = var.ses_secret_access_key
+        "ses_secret_sender_arn" = var.ses_secret_sender_arn
+        "ses_configuration_set_name" = var.ses_configuration_set_name
     })
 }
 

--- a/terraform/aws_secrets/variables.tf
+++ b/terraform/aws_secrets/variables.tf
@@ -1,8 +1,8 @@
-variable "ses_access_key_id" {
+variable "ses_secret_sender_arn" {
   type = string
 }
 
-variable "ses_secret_access_key" {
+variable "ses_configuration_set_name" {
   type = string
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,3 +3,10 @@ provider "aws" {
   access_key = var.access_key
   secret_key = var.secret_key
 }
+
+provider "aws" {
+  region  = "us-east-1"
+  access_key = var.access_key
+  secret_key = var.secret_key
+  alias   = "east-1-provider"
+}

--- a/terraform/modules.tf
+++ b/terraform/modules.tf
@@ -151,5 +151,9 @@ module "sqs_queues" {
 module "ses" {
   source = "./ses"
 
+  providers = {
+    aws = aws.east-1-provider
+  }
+
   ses_configuration_set_name = var.ses_configuration_set_name
 }

--- a/terraform/modules.tf
+++ b/terraform/modules.tf
@@ -30,8 +30,8 @@ module "s3" {
 module "aws_secrets" {
   source = "./aws_secrets"
 
-  ses_access_key_id = var.ses_access_key_id
-  ses_secret_access_key = var.ses_secret_access_key
+  ses_secret_sender_arn = var.ses_secret_sender_arn
+  ses_configuration_set_name = var.ses_configuration_set_name
   ornl_endpoint_url = var.ornl_endpoint_url
   ornl_endpoint_access_token = var.ornl_endpoint_access_token
   gesdisc_endpoint_url = var.gesdisc_endpoint_url
@@ -146,4 +146,10 @@ module "sqs_queues" {
   account_id = var.account_id
   stage = var.stage
   edpub_event_sns_arn = module.sns_topics.edpub_event_sns_arn
+}
+
+module "ses" {
+  source = "./ses"
+
+  ses_configuration_set_name = var.ses_configuration_set_name
 }

--- a/terraform/ses/main.tf
+++ b/terraform/ses/main.tf
@@ -14,5 +14,5 @@ resource "aws_sesv2_configuration_set" "edpub_configuration_set" {
     sending_enabled = true
   }
 
-  tags = []
+  tags = {}
 }

--- a/terraform/ses/main.tf
+++ b/terraform/ses/main.tf
@@ -1,0 +1,20 @@
+resource "aws_sesv2_configuration_set" "edpub_configuration_set" {
+  
+  provider = aws.east-1-provider
+
+  configuration_set_name = var.ses_configuration_set_name
+
+  delivery_options {
+    tls_policy = "REQUIRE"
+  }
+
+  reputation_options {
+    reputation_metrics_enabled = true
+  }
+
+  sending_options {
+    sending_enabled = true
+  }
+
+  tags = []
+}

--- a/terraform/ses/main.tf
+++ b/terraform/ses/main.tf
@@ -1,3 +1,11 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
 resource "aws_sesv2_configuration_set" "edpub_configuration_set" {
 
   configuration_set_name = var.ses_configuration_set_name

--- a/terraform/ses/main.tf
+++ b/terraform/ses/main.tf
@@ -1,6 +1,4 @@
 resource "aws_sesv2_configuration_set" "edpub_configuration_set" {
-  
-  provider = aws.east-1-provider
 
   configuration_set_name = var.ses_configuration_set_name
 

--- a/terraform/ses/outputs.tf
+++ b/terraform/ses/outputs.tf
@@ -1,0 +1,3 @@
+output "edpub_configuration_set_arn" {
+  value = aws_sesv2_configuration_set.edpub_configuration_set.arn
+}

--- a/terraform/ses/variables.tf
+++ b/terraform/ses/variables.tf
@@ -1,0 +1,3 @@
+variable "ses_configuration_set_name" {
+  type = string
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -108,11 +108,11 @@ variable "ses_from_email"{
   type = string
 }
 
-variable "ses_access_key_id" {
+variable "ses_secret_sender_arn" {
   type = string
 }
 
-variable "ses_secret_access_key" {
+variable "ses_configuration_set_name" {
   type = string
 }
 


### PR DESCRIPTION
# Description

Creates a ConfigurationSet resource in terraform based off the CCS example configuration

## Spec

See Ticket: https://bugs.earthdata.nasa.gov/browse/EDPUB-1456

---

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches to SIT.
3. In AWS, navigate to AWS Secrets Manager
4. Verify that the `sess_access_creds` secret has the following keys
- ses_secret_sender_arn
- ses_configuration_set_name
5. Navigate to the Amazon SES Page and click on Configuration sets
6. Verify the configuration set matches the CCS example

---
