### PR TITLE
EDPUB-1338: Troubleshoot Session Extension Not Working fix

### DIFF
--- a/src/nodejs/lambda-layers/auth-util/src/auth-util.js
+++ b/src/nodejs/lambda-layers/auth-util/src/auth-util.js
@@ -49,7 +49,7 @@ async function refreshToken({ token }) {
     refresh_token: token
   });
   const decoded = jwt.decode(tokens.id_token);
-  const refresh = tokens.refresh_token;
+  const refresh = token;
   const access = tokens.access_token;
   return { access, refresh, decoded };
 }


### PR DESCRIPTION
# Description

In testing, the extend session prompt which occurs before session timeout doesn't appear to be working properly resulting in the session still timing out. This task is to troubleshoot why that is and resolve the issue.


## Spec

See Ticket: [EDPUB-1338](https://bugs.earthdata.nasa.gov/browse/EDPUB-1338)

---

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Make sure the session extends when you click on the extend button (This can be tested by reducing the session duration within Cognito to the minimum (rather than waiting an hour for the session to timeout))