### PR TITLE
EDPUB-1470: Update EDPub API pgadmin to pull latest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,10 +53,11 @@ services:
     ports:
       - 5432:5432
   pg_admin:
-    image: dpage/pgadmin4
+    image: dpage/pgadmin4:latest
     restart: always
     environment:
       PGADMIN_DEFAULT_EMAIL: edpub@edpub.com
       PGADMIN_DEFAULT_PASSWORD: edpub
+      PGADMIN_CONFIG_UPGRADE_CHECK_ENABLED: "False"
     ports:
       - 8001:80


### PR DESCRIPTION
# Description

There's currently a warning that shows on the pgadmin webpage locally describing a new version availability. The pgadmin docker should be updated to utilize the latest version


## Spec


See Ticket: [EDPUB-1470](https://bugs.earthdata.nasa.gov/browse/EDPUB-1470)

---

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Navigate to pgadmin and check if the message is not appearing anymore. 
