### PR TITLE
Hotfix: Fix upload error when user not assigned to a group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 <!-- Unreleased changes can be added here. -->
 - Add attachments capabilities
 - Updated github repo template assets
+- Fix upload error for users not assigned to a group
 
 ## 1.1.0
 

--- a/src/nodejs/lambda-handlers/file-upload.js
+++ b/src/nodejs/lambda-handlers/file-upload.js
@@ -62,12 +62,12 @@ async function getPostUrlMethod(event, user) {
     } = await db.submission.findById({ id: submissionId });
     if (!daacId) return ({ error: 'Submission not found' });
 
-    const userDaacs = (await db.daac.getIds({ group_ids: groupIds }))
-      .map((daac) => daac.id);
+    const userDaacs = groupIds.length > 0 ? await db.daac.getIds({ group_ids: groupIds }) : [];
+    const userDaacIds = userDaacs.map((daac) => daac.id);
 
     if (contributorIds.includes(user)
       || userInfo.user_privileges.includes('ADMIN')
-      || userDaacs.includes(daacId)
+      || userDaacIds.includes(daacId)
     ) {
       return generateUploadUrl({
         key: `${daacId}/${submissionId}/${fileCategory}/${user}/${fileName}`,
@@ -171,8 +171,9 @@ async function listFilesMethod(event, user) {
   const { submission_id: submissionId } = event;
   const userInfo = await db.user.findById({ id: user });
   const groupIds = userInfo.user_groups.map((group) => group.id);
-  const userDaacs = (await db.daac.getIds({ group_ids: groupIds }))
-    .map((daac) => daac.id);
+  const userDaacs = groupIds.length > 0 ? await db.daac.getIds({ group_ids: groupIds }) : [];
+  const userDaacIds = userDaacs.map((daac) => daac.id);
+
   const {
     daac_id: daacId,
     contributor_ids: contributorIds
@@ -180,7 +181,7 @@ async function listFilesMethod(event, user) {
 
   if (contributorIds.includes(user)
     || userInfo.user_privileges.includes('ADMIN')
-    || userDaacs.includes(daacId)
+    || userDaacIds.includes(daacId)
   ) {
     const s3Client = new S3Client({ region });
     const command = new ListObjectsCommand({ Bucket: ingestBucket, Prefix: `${daacId}/${submissionId}` });
@@ -213,14 +214,15 @@ async function getDownloadUrlMethod(event, user) {
   const submissionId = key.split('/')[1];
   const userInfo = await db.user.findById({ id: user });
   const groupIds = userInfo.user_groups.map((group) => group.id);
-  const userDaacs = (await db.daac.getIds({ group_ids: groupIds }))
-    .map((daac) => daac.id);
+  const userDaacs = groupIds.length > 0 ? await db.daac.getIds({ group_ids: groupIds }) : [];
+  const userDaacIds = userDaacs.map((daac) => daac.id);
+
   const {
     daac_id: daacId
   } = await db.submission.findById({ id: submissionId });
 
   if (userInfo.user_privileges.includes('ADMIN')
-    || userDaacs.includes(daacId)
+    || userDaacIds.includes(daacId)
   ) {
     const payload = {
       Bucket: ingestBucket,


### PR DESCRIPTION
## Description

Upload silently failing when user is not assigned to a group due to internal error. I updated the code so that we try to get the group ids if the user has groups assigned to it. I also separated query from id mapping to avoid error like
```
(intermediate value).map is not a function
```

## Linked JIRA Task or Github Issue

N/A

## Types of changes

What types of changes does your code introduce to Earthdata Pub (EDPub)?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [ ] Other (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CHANGELOG.md)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Validation Steps

1. Make sure all merge request checks have passed (CI/CD).
2. Push the branch to SIT.
3. Log into SIT with a data producer user not assigned to a group.
4. Create a new request.
5. Confirm you can upload a file on the request overview page.
