### PR TITLE
Hotfix: Remove daac id filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updated github repo template assets
 - Fix upload error for users not assigned to a group
 - Add default publication workflow
+- Update request details db query to remove daac long name from response
 
 ## 1.1.0
 

--- a/src/nodejs/lambda-layers/database-util/src/query/submission.js
+++ b/src/nodejs/lambda-layers/database-util/src/query/submission.js
@@ -745,11 +745,11 @@ const getStepName = () => `
 SELECT step_name FROM submission_status WHERE id = {{id}}
 `;
 
-// TODO - Upate this query's complexity and to use sql builder
+// TODO - Update this query's complexity and to use sql builder
 const getSubmissionDetailsById = (params) => `
 WITH step_visibility AS (SELECT step.*, upload_step.id AS upload_step_id, form.daac_only FROM step LEFT JOIN form ON step.form_id = form.id LEFT JOIN upload_step ON step.step_name = upload_step.step_name),
 filteredForm AS (SELECT * FROM form ${params.privilegedUser === false ? `WHERE form.daac_only=false`: ``})
-SELECT submission.id id, conversation_id, submission.created_at created_at, daac.long_name daac_name, 
+SELECT submission.id id, conversation_id, submission.created_at created_at,
 submission.hidden hidden,
 JSONB_BUILD_OBJECT('name', edpuser1.name, 'id', edpuser1.id) initiator,
 submission_status.last_change last_change,
@@ -769,8 +769,6 @@ CASE
       'long_name', filteredForm.long_name, 'daac_only', filteredForm.daac_only, 'submitted_at', submission_form_data.submitted_at))) 
 END forms, submission_metadata.metadata metadata
 FROM submission
-JOIN daac
-ON submission.daac_id = daac.id
 JOIN edpuser edpuser1
 ON submission.initiator_edpuser_id = edpuser1.id
 JOIN submission_status
@@ -792,7 +790,7 @@ ON submission_form_data.form_id = filteredForm.id
 JOIN submission_metadata
 ON submission.id = submission_metadata.id
 WHERE submission.id= {{id}}
-GROUP BY submission.id, daac.long_name, edpuser1.name, edpuser1.id,
+GROUP BY submission.id, edpuser1.name, edpuser1.id,
 submission_status.last_change, workflow.long_name, workflow.id,
 submission_form_data_pool.data, step_visibility.type, step_visibility.step_name, step_visibility.action_id, step_visibility.upload_step_id,
 step_visibility.form_id, step_visibility.service_id, step_visibility.data, step_visibility.daac_only, filteredForm.id, 


### PR DESCRIPTION
## Description

Accession request now begin without being assigned to a DAAC. This was causing issue with the request details API query because it assumed a DAAC was assigned in order to provide the DAAC long name. Because of this change and not really needing the DAAC long name even if the request is assigned, it is simplest just to remove this join.

## Types of changes

What types of changes does your code introduce to Earthdata Pub (EDPub)?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [ ] Other (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CHANGELOG.md)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Validation Steps

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally (one in API and dashboard).
3. Sign into the dashboard.
4. Create a new accession request
5. Navigate to the request details page of the new accession request.
6. Confirm that the page loads with information related to the new accession request.
