### PR TITLE
Updating notes to be associated with the submission's daac at time of…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fix upload error for users not assigned to a group
 - Add default publication workflow
 - Update request details db query to remove daac long name from response
+- Update notes to be associated with the submission's daac at time of creation
 
 ## 1.1.0
 

--- a/src/nodejs/lambda-layers/database-util/src/query/note.js
+++ b/src/nodejs/lambda-layers/database-util/src/query/note.js
@@ -160,11 +160,9 @@ const refs = {
           },
           alias: 'note_visibility',
           where: { 
-            conjunction: 'OR',
             filters: [
-              ...([{cmd: `{{user_id}}=ANY(note_scope.user_ids)` }]),
               ...([{
-                cmd: `note.id IN (${sql.select({
+                cmd: `({{user_id}}=ANY(note_scope.user_ids) OR note.id IN (${sql.select({
                   fields: ['note.id'],
                   from: {
                     base: 'note',
@@ -210,8 +208,17 @@ const refs = {
                       }])
                     ]
                   }
-                })})`
-              }])
+                })}))`
+              }]),
+              ...([{cmd: `(note.daac_id IS NULL OR note.daac_id=(${sql.select({
+                fields: [
+                  'daac_id',
+                ],
+                from: {
+                  base: 'submission'
+                },
+                where: { filters: [{ field: 'submission.conversation_id', param: 'conversation_id' }] } 
+              })}))`}])
             ]
            }
         }),
@@ -265,11 +272,9 @@ const refs = {
           },
           alias: 'note_visibility',
           where: { 
-            conjunction: 'OR',
             filters: [
-              ...([{cmd: `{{user_id}}=ANY(note_scope.user_ids)` }]),
               ...([{
-                cmd: `note.id IN (${sql.select({
+                cmd: `({{user_id}}=ANY(note_scope.user_ids) OR note.id IN (${sql.select({
                   fields: ['note.id'],
                   from: {
                     base: 'note',
@@ -315,8 +320,17 @@ const refs = {
                       }])
                     ]
                   }
-                })})`
-              }])
+                })}))`
+              }]),
+              ...([{cmd: `(note.daac_id IS NULL OR note.daac_id=(${sql.select({
+                fields: [
+                  'daac_id',
+                ],
+                from: {
+                  base: 'submission'
+                },
+                where: { filters: [{ field: 'submission.conversation_id', param: 'conversation_id' }] } 
+              })}))`}])
             ]
            }
         }),
@@ -448,9 +462,9 @@ SELECT note.*
 FROM note 
 LEFT join submission ON note.conversation_id = submission.conversation_id
 LEFT JOIN note_scope ON note.id = note_scope.note_id
-WHERE note.id = '${params.id}' AND (
-	'${params.user_id}' = ANY(SELECT edpuser_id FROM edpuser_edprole NATURAL JOIN edprole_privilege WHERE privilege = 'ADMIN') OR (
-		( '${params.user_id}' = ANY(submission.contributor_ids) OR '${params.user_id}' = ANY(
+WHERE note.id = {{id}} AND (
+	  {{user_id}} = ANY(SELECT edpuser_id FROM edpuser_edprole NATURAL JOIN edprole_privilege WHERE privilege = 'ADMIN') OR (
+		( {{user_id}} = ANY(submission.contributor_ids) OR {{user_id}} = ANY(
 			SELECT id
 			FROM edpuser
 			LEFT JOIN edpuser_edpgroup ON edpuser.id = edpuser_edpgroup.edpuser_id 
@@ -461,10 +475,10 @@ WHERE note.id = '${params.id}' AND (
 					FROM note
 					LEFT join submission ON note.conversation_id = submission.conversation_id 
 					LEFT JOIN daac ON submission.daac_id = daac.id 
-					WHERE note.id = '${params.id}')
+					WHERE note.id = {{id}})
 			)
 		) AND (
-			'${params.user_id}' =ANY(note_scope.user_ids) 
+			({{user_id}} =ANY(note_scope.user_ids) 
 			OR note.id in (
 				SELECT note.id
 				FROM note
@@ -478,10 +492,13 @@ WHERE note.id = '${params.id}' AND (
 						WHERE unraveled.role_id IN (
 								SELECT edprole_id 
 								FROM edpuser_edprole WHERE 
-								edpuser_id = '${params.user_id}'
+								edpuser_id = {{user_id}}
 						)
 					)			
 				)
+      ) AND (
+        note.daac_id IS NULL 
+        OR note.daac_id=(SELECT daac_id FROM submission WHERE conversation_id = (SELECT conversation_id FROM note WHERE note.id={{id}})))
 		)
 	)
 )
@@ -639,8 +656,10 @@ ${params.user_id && !params.daac ?
 `;
 
 const reply = (params) => `
-WITH new_note AS (INSERT INTO note(conversation_id, sender_edpuser_id, text${params.step_name?`, step_name`:''}) VALUES
- ({{conversation_id}}, {{user_id}}, {{text}}${params.step_name?`, {{step_name}}`:''})
+WITH submission_daac AS (SELECT daac_id FROM submission WHERE conversation_id = {{conversation_id}}), 
+new_note AS (INSERT INTO note(conversation_id, sender_edpuser_id, text${params.step_name?`, step_name`:''}, daac_id) VALUES
+ ({{conversation_id}}, {{user_id}}, {{text}}${params.step_name?`, {{step_name}}`:''}, 
+ ${params.user_id === '1b10a09d-d342-4eee-a9eb-c99acd2dde17' ?  null : `(SELECT daac_id FROM submission_daac)`})
 RETURNING *),
 conversation_update AS (UPDATE conversation SET
  last_change = new_note.created_at

--- a/src/postgres/2-tables.sql
+++ b/src/postgres/2-tables.sql
@@ -603,11 +603,13 @@ CREATE TABLE IF NOT EXISTS note (
   created_at TIMESTAMP NOT NULL DEFAULT NOW(),
   step_name VARCHAR,
   attachments VARCHAR[],
+  daac_id UUID,
   PRIMARY KEY (id),
   FOREIGN KEY (conversation_id) REFERENCES conversation (id),
   FOREIGN KEY (sender_edpuser_id) REFERENCES edpuser (id),
   UNIQUE (id),
-  FOREIGN KEY (step_name) REFERENCES step (step_name)
+  FOREIGN KEY (step_name) REFERENCES step (step_name),
+  FOREIGN KEY (daac_id) REFERENCES daac(id)
 );
 
 -- Create a custom ENUM type

--- a/src/postgres/9-updates.sql
+++ b/src/postgres/9-updates.sql
@@ -359,3 +359,7 @@ UPDATE daac SET hidden = 'false' WHERE id = '00dcf32a-a4e2-4e55-a0d1-3a74cf100ca
 UPDATE step SET data='{"rollback":"data_accession_request_form_review","type": "review"}' WHERE step_name='daac_assignment';
 DELETE FROM step WHERE workflow_id='3335970e-8a9b-481b-85b7-dfaaa3f5dbd9' AND step_name='cost_model';
 UPDATE step_edge SET next_step_name='daac_assignment' WHERE workflow_id='3335970e-8a9b-481b-85b7-dfaaa3f5dbd9' AND step_name='data_accession_request_form_review';
+
+-- 3/21/25 Update notes to be associated with the submission's daac at time of creation
+ALTER TABLE note ADD daac_id UUID;
+ALTER TABLE note ADD FOREIGN KEY (daac_id) REFERENCES daac(id);


### PR DESCRIPTION
## Description

Associates notes made by users to the DAAC assigned to the submission at the time of the notes creation. If the note is made by the EDPUB system no DAAC is assigned to ensure visibility of all system messages. Notes created by users under one DAAC will no longer be visible to anyone but Admins and ROOT Observers if the DAAC associated with the submission changes.

## Linked JIRA Task or Github Issue

JIRA Task: https://bugs.earthdata.nasa.gov/browse/EDPUB-1501

## Types of changes

What types of changes does your code introduce to Earthdata Pub (EDPub)?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [ ] Other (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CHANGELOG.md)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Validation Steps

_This will help us get a jump start on validating your PR by describing the steps to replicate
and validate the expected behavior. (For an example of good validation instructions, check out [Bryan's Bouncy Ball PR.](https://github.com/sparkbox/bouncy-ball/pull/56#issue-192153701))_

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Create a new submission as a no-daac Data Producer
4. Manually set the daac for the submission to GESDISC
5. Log out and log in as a GESDISC DAAC Staff user
6. Navigate to a review step for the submission
7. Make a comment
8. Manually set the daac for the submission to ORNL
9. Log out and log back in as an ORNL DAAC Staff user
10. On the Conversations page verify that the comment made by the GESDISC user is not visible
11. Leave a comment
12. Log out and log in as A ROOT Group Observer
13. Navigate to the conversations page
14. Verify that both comments are visible

## Further comments
Something to keep in mind - If for whatever reason a user has been added to the submission when their DAAC was assigned, but then the assigned DAAC changes, they will still have visibility permissions at the level of their role regardless of whether their DAAC matches the DAAC associated with the note. I.e. An ORNL DAAC Staff would have the same visibility as a GES DISC DAAC Staff member on a submission that both were listed as contributors for - but only notes for the currently assigned DAAC would be visible.