### PR TITLE
Remove NOT NULL clause to support backfill codes

### DIFF
--- a/src/postgres/2-tables.sql
+++ b/src/postgres/2-tables.sql
@@ -647,7 +647,7 @@ CREATE TABLE IF NOT EXISTS code (
 
 CREATE TABLE IF NOT EXISTS publication_accession_association (
   publication_submission_id UUID NOT NULL,
-  accession_submission_id UUID NOT NULL,
+  accession_submission_id UUID,
   code UUID NOT NULL,
   PRIMARY KEY (publication_submission_id),
   FOREIGN KEY (publication_submission_id) REFERENCES submission (id),

--- a/src/postgres/9-updates.sql
+++ b/src/postgres/9-updates.sql
@@ -188,7 +188,7 @@ DELETE FROM step_edge WHERE workflow_id='a5a14d98-df13-47f2-b86b-1504c7d4360d' A
 -- 12/9/24 Create accession_publication_code DB Association
 CREATE TABLE IF NOT EXISTS publication_accession_association (
   publication_submission_id UUID NOT NULL,
-  accession_submission_id UUID NOT NULL,
+  accession_submission_id UUID,
   code UUID NOT NULL,
   PRIMARY KEY (publication_submission_id),
   FOREIGN KEY (publication_submission_id) REFERENCES submission (id),


### PR DESCRIPTION
## Description

Removed NOT NULL clause to support backfill codes since they are not associated with an existing accession request.

## Types of changes

What types of changes does your code introduce to Earthdata Pub (EDPub)?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [ ] Other (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CHANGELOG.md)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Validation Steps

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Sign into the dashboard.
4. Using a db editor, populate the backfill codes.
5. Confirm you can use one of the backfill codes to create a data publication request.