### PR TITLE
Hotfix: Fix various privileges and queries

### DIFF
--- a/src/nodejs/lambda-layers/database-util/src/query/submission.js
+++ b/src/nodejs/lambda-layers/database-util/src/query/submission.js
@@ -154,7 +154,7 @@ const daacIdSelect = () => sql.select({
   where: {
     filters: [{ field: 'submission.id', param: 'id' }]
   }
-})
+});
 
 const daacGroup = () => ({
   type: 'inner_join',
@@ -226,13 +226,7 @@ const submissionPrivilegedUsers = () => ({
             `(${daacIdSelect()})`,
             'array_agg(edpuser_id) user_ids'
           ],
-          from: {
-            base: sql.union({
-              query1: submissionDaacUsers(),
-              query2: adminUsers(),
-              alias: 'user_union'
-            })
-          },
+          base: `(${submissionDaacUsers()})`,
           alias: 'daac_privileged_users'
         })
       },
@@ -289,7 +283,7 @@ const findById = (params) => sql.select({
   where: {
     filters: [
       { field: fieldMap.id, param: 'id' },
-      ...([{ cmd: `('${params.user_id}'=ANY(submission.contributor_ids) OR '${params.user_id}' = ANY(privileged_users.user_ids))` }]),
+      ...([{ cmd: `({{user_id}}=ANY(submission.contributor_ids) OR {{user_id}} = ANY(privileged_users.user_ids)) OR '4daa6b22-f015-4ce2-8dac-8b3510004fca' = ANY(SELECT EDPGROUP_ID FROM EDPUSER_EDPGROUP WHERE EDPUSER_ID={{user_id}})` }]),
     ]
   }
 });
@@ -329,7 +323,7 @@ const getDaacSubmissions = (params) => sql.select({
   where: {
       conjunction: 'OR',
       filters: [
-        ...(params.user_id ? [{cmd: `initiator ->> 'id' = {{user_id}}`}] : []),
+        ...(params.user_id ? [{cmd: `initiator ->> 'id' = {{user_id}}`}, {cmd: `{{user_id}} = ANY(contributor_ids)`}] : []),
         ...(params.daac ? [{
           field: 'conversation_id',
           any: {

--- a/src/nodejs/lambda-layers/database-util/src/query/submission.js
+++ b/src/nodejs/lambda-layers/database-util/src/query/submission.js
@@ -226,7 +226,9 @@ const submissionPrivilegedUsers = () => ({
             `(${daacIdSelect()})`,
             'array_agg(edpuser_id) user_ids'
           ],
-          base: `(${submissionDaacUsers()})`,
+          from: {
+            base: `(${submissionDaacUsers()})`
+          },
           alias: 'daac_privileged_users'
         })
       },

--- a/src/postgres/7-seed.sql
+++ b/src/postgres/7-seed.sql
@@ -410,6 +410,8 @@ INSERT INTO edprole_privilege VALUES ('2aa89c57-85f1-4611-812d-b6760bb6295c', 'C
 INSERT INTO edprole_privilege VALUES ('2aa89c57-85f1-4611-812d-b6760bb6295c', 'REMOVE_STEPREVIEW');
 INSERT INTO edprole_privilege VALUES ('2aa89c57-85f1-4611-812d-b6760bb6295c', 'NOTE_REPLY');
 INSERT INTO edprole_privilege VALUES ('2aa89c57-85f1-4611-812d-b6760bb6295c', 'METRICS_READ');
+INSERT INTO edprole_privilege VALUES ('2aa89c57-85f1-4611-812d-b6760bb6295c', 'NOTE_ADDUSER');
+INSERT INTO edprole_privilege VALUES ('2aa89c57-85f1-4611-812d-b6760bb6295c', 'NOTE_REMOVEUSER');
 
 --RolePrivilege(edprole_id, privilege) Observer
 INSERT INTO edprole_privilege VALUES ('4be6ca4d-6362-478b-8478-487a668314b1', 'REQUEST_DAACREAD');
@@ -421,6 +423,8 @@ INSERT INTO edprole_privilege VALUES ('4be6ca4d-6362-478b-8478-487a668314b1', 'N
 INSERT INTO edprole_privilege VALUES ('4be6ca4d-6362-478b-8478-487a668314b1', 'NOTE_ADDUSER');
 INSERT INTO edprole_privilege VALUES ('4be6ca4d-6362-478b-8478-487a668314b1', 'NOTE_REMOVEUSER');
 INSERT INTO edprole_privilege VALUES ('4be6ca4d-6362-478b-8478-487a668314b1', 'METRICS_READ');
+INSERT INTO edprole_privilege VALUES ('4be6ca4d-6362-478b-8478-487a668314b1', 'CREATE_STEPREVIEW');
+INSERT INTO edprole_privilege VALUES ('4be6ca4d-6362-478b-8478-487a668314b1', 'REMOVE_STEPREVIEW');
 
 -- UserRole(edpuser_id, edprole_id)
 INSERT INTO edpuser_edprole VALUES ('1b10a09d-d342-4eee-a9eb-c99acd2dde17', '75605ac9-bf65-4dec-8458-93e018dcca97');

--- a/src/postgres/9-updates.sql
+++ b/src/postgres/9-updates.sql
@@ -229,3 +229,11 @@ INSERT INTO privilege VALUES ('METRICS_READ');
 INSERT INTO edprole_privilege VALUES ('a5b4947a-67d2-434e-9889-59c2fad39676', 'METRICS_READ');
 INSERT INTO edprole_privilege VALUES ('2aa89c57-85f1-4611-812d-b6760bb6295c', 'METRICS_READ');
 INSERT INTO edprole_privilege VALUES ('4be6ca4d-6362-478b-8478-487a668314b1', 'METRICS_READ');
+
+-- 4/4/25 Allow Observer role to create/remove step review approval requirements
+INSERT INTO edprole_privilege VALUES ('4be6ca4d-6362-478b-8478-487a668314b1', 'CREATE_STEPREVIEW');
+INSERT INTO edprole_privilege VALUES ('4be6ca4d-6362-478b-8478-487a668314b1', 'REMOVE_STEPREVIEW');
+
+-- 4/4/25 Allow Data Manager to limit note visibility
+INSERT INTO edprole_privilege VALUES ('2aa89c57-85f1-4611-812d-b6760bb6295c', 'NOTE_ADDUSER');
+INSERT INTO edprole_privilege VALUES ('2aa89c57-85f1-4611-812d-b6760bb6295c', 'NOTE_REMOVEUSER');


### PR DESCRIPTION
## Description

Fix the following issues:

- Root group users not seeing all requests when using submissionFindById db query
- DAAC users not seeing requests which they are a contributor to, if request is not assigned to their DAAC
- Observers unable to create/remove step review approval requirements
- Data Managers unable to limit note visibility

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [ ] Other (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CHANGELOG.md)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Validation Steps

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Create a Data Producer user (don't select a DAAC)
4. Create a new Data Accession request
5. Sign Out
6. Create an observer with root group user
7. Authenticate to swagger with the observer auth token
8. Use the submission/{id} endpoint to validate that the observer user can access the submission

----

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Create a DAAC staff user with the GHRC DAAC.
4. Sign Out
5. Sign in as the Earthdata Pub System user
6. Create a new request to the ORNL DAAC
7. Move the request to the DAR form review step.
8. Assign the GHRC DAAC staff user as a review.
9. Validate that they are added as a contributor on the request details overview page.
10. Sign out.
11. Sign in as the GHRC DAAC staff user.
12. Validate that you can see the ORNL DAAC request since you are a contributor

----

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Create a new request
4. Sign Out
5. Create a new DAAC staff user for the GHRC DAAC
6. Sign Out
7. Create a new observer user for the root group
8. Change the request step to be at the DAR form review step.
9. Add the GHRC DAAC staff as a reviewer to the request

----

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Create a new request for GHRC DAAC as the Earthdata Pub System user.
4. Move the request to the DAR form review step
5. Sign Out
6. Create a new DAAC Data Manager user with the GHRC DAAC
7. Navigate to the DAR form review
8. Confirm that you see the buttons for limiting note visibility.