### PR TITLE
Hotfix: Add missing alias to subquery

### DIFF
--- a/src/nodejs/lambda-layers/database-util/src/query/submission.js
+++ b/src/nodejs/lambda-layers/database-util/src/query/submission.js
@@ -192,8 +192,7 @@ const submissionDaacUsers = () => sql.select({
   },
   where: {
     filters: [{ field: 'edprole_privilege.privilege', literal: "REQUEST_DAACREAD" }]
-  },
-  alias: 'daac_privileged_users_subquery'
+  }
 });
 
 const adminUsers = () => sql.select({
@@ -228,7 +227,7 @@ const submissionPrivilegedUsers = () => ({
             'array_agg(edpuser_id) user_ids'
           ],
           from: {
-            base: `(${submissionDaacUsers()})`
+            base: `(${submissionDaacUsers()}) daac_privileged_users_subquery`
           },
           alias: 'daac_privileged_users'
         })

--- a/src/nodejs/lambda-layers/database-util/src/query/submission.js
+++ b/src/nodejs/lambda-layers/database-util/src/query/submission.js
@@ -209,7 +209,8 @@ const adminUsers = () => sql.select({
   },
   where: {
     filters: [{ field: 'edprole_privilege.privilege', literal: "ADMIN" }]
-  }
+  },
+  alias: 'daac_privileged_users_subquery'
 });
 
 const submissionPrivilegedUsers = () => ({

--- a/src/nodejs/lambda-layers/database-util/src/query/submission.js
+++ b/src/nodejs/lambda-layers/database-util/src/query/submission.js
@@ -192,7 +192,8 @@ const submissionDaacUsers = () => sql.select({
   },
   where: {
     filters: [{ field: 'edprole_privilege.privilege', literal: "REQUEST_DAACREAD" }]
-  }
+  },
+  alias: 'daac_privileged_users_subquery'
 });
 
 const adminUsers = () => sql.select({
@@ -209,8 +210,7 @@ const adminUsers = () => sql.select({
   },
   where: {
     filters: [{ field: 'edprole_privilege.privilege', literal: "ADMIN" }]
-  },
-  alias: 'daac_privileged_users_subquery'
+  }
 });
 
 const submissionPrivilegedUsers = () => ({


### PR DESCRIPTION
## Description

Fix database error like
```
error: error: subquery in FROM must have an alias
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [ ] Other (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CHANGELOG.md)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Validation Steps

1. Make sure all merge request checks have passed (CI/CD).
2. Push the related branches to SIT.
3. Navigate to an existing accession/publication request form.
4. Ensure that the page loads as expected
