### PR TITLE
Hotfix: Resolving dashboard api gateway mapping errors

### DIFF
--- a/src/nodejs/lambda-handlers/remap-statics.js
+++ b/src/nodejs/lambda-handlers/remap-statics.js
@@ -1,6 +1,5 @@
 /**
- * Lambda to update request templates in the api after redeploying the overview,
- * dashboard, and/or forms apps
+ * Lambda to update request templates in the api after redeploying the dashboard app
  * @module RemapStatics
  */
 
@@ -12,7 +11,6 @@ const stage = process.env.STAGE;
 const apiId = process.env.API_ID;
 
 const staticSites = {
-  overview: { bucket: process.env.OVERVIEW_BUCKET, path: '/{key+}' },
   dashboard: { bucket: process.env.DASHBOARD_BUCKET, path: '/dashboard/{key+}' }
 };
 
@@ -20,7 +18,6 @@ const s3 = new S3({ region });
 const apigateway = new APIGateway({ region });
 
 function getResourceIds() {
-  console.log(`apigateway reponse`, apigateway.getResources({ restApiId: apiId, limit: '500' });
   return new Promise((resolve, reject) => {
     apigateway.getResources({ restApiId: apiId, limit: '500' }, (err, data) => {
       if (err) { reject(err); } else {
@@ -87,7 +84,6 @@ async function deployChanges() {
 
 async function handler() {
   const resourceIds = await getResourceIds();
-  console.log(`resourceIds:`, resourceIds);
   await Promise.all(Object.entries(staticSites).map(async ([key, site]) => {
     console.info(`Mapping '${key}'`);
     const mappings = await getS3Mappings(site.bucket);

--- a/src/nodejs/lambda-handlers/remap-statics.js
+++ b/src/nodejs/lambda-handlers/remap-statics.js
@@ -20,6 +20,7 @@ const s3 = new S3({ region });
 const apigateway = new APIGateway({ region });
 
 function getResourceIds() {
+  console.log(`apigateway reponse`, apigateway.getResources({ restApiId: apiId, limit: '500' });
   return new Promise((resolve, reject) => {
     apigateway.getResources({ restApiId: apiId, limit: '500' }, (err, data) => {
       if (err) { reject(err); } else {
@@ -86,6 +87,7 @@ async function deployChanges() {
 
 async function handler() {
   const resourceIds = await getResourceIds();
+  console.log(`resourceIds:`, resourceIds);
   await Promise.all(Object.entries(staticSites).map(async ([key, site]) => {
     console.info(`Mapping '${key}'`);
     const mappings = await getS3Mappings(site.bucket);


### PR DESCRIPTION
Hitting error in remap statics step due to removal of wildcard overview application endpoints. Removing this element removes the search for application specific mappings within openapi.json for the overview application.