### PR TITLE
Add missing parantheses to submission.findById cmd

### DIFF
--- a/src/nodejs/lambda-layers/database-util/src/query/submission.js
+++ b/src/nodejs/lambda-layers/database-util/src/query/submission.js
@@ -285,7 +285,7 @@ const findById = (params) => sql.select({
   where: {
     filters: [
       { field: fieldMap.id, param: 'id' },
-      ...([{ cmd: `({{user_id}}=ANY(submission.contributor_ids) OR {{user_id}} = ANY(privileged_users.user_ids)) OR '4daa6b22-f015-4ce2-8dac-8b3510004fca' = ANY(SELECT EDPGROUP_ID FROM EDPUSER_EDPGROUP WHERE EDPUSER_ID={{user_id}})` }]),
+      ...([{ cmd: `(({{user_id}}=ANY(submission.contributor_ids) OR {{user_id}} = ANY(privileged_users.user_ids)) OR '4daa6b22-f015-4ce2-8dac-8b3510004fca' = ANY(SELECT EDPGROUP_ID FROM EDPUSER_EDPGROUP WHERE EDPUSER_ID={{user_id}}))` }]),
     ]
   }
 });


### PR DESCRIPTION
## Description

With the explicit parentheses, submission id will not be used as a filter.

## Types of changes

What types of changes does your code introduce to Earthdata Pub (EDPub)?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [ ] Other (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CHANGELOG.md)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Validation Steps

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Create two new requests as the system user.
4. Create a new user with observer role and root group access.
5. Use the observer account to authenticate to swagger
6. Query the submission/{id} endpoint with the id of the second request you created.
7. Validate that the response is correct for the second request.
