### PR TITLE
Removing DAAC Id references to handle submissions without an assigned…

### DIFF
--- a/src/nodejs/lambda-handlers/file-upload.js
+++ b/src/nodejs/lambda-handlers/file-upload.js
@@ -60,7 +60,7 @@ async function getPostUrlMethod(event, user) {
       daac_id: daacId,
       contributor_ids: contributorIds
     } = await db.submission.findById({ id: submissionId, user_id: userInfo.id });
-    if (!daacId) return ({ error: 'Submission not found' });
+    if (!contributorIds) return ({ error: 'Submission not found' });
 
     const userDaacs = groupIds.length > 0 ? await db.daac.getIds({ group_ids: groupIds }) : [];
     const userDaacIds = userDaacs.map((daac) => daac.id);
@@ -70,7 +70,7 @@ async function getPostUrlMethod(event, user) {
       || userDaacIds.includes(daacId)
     ) {
       return generateUploadUrl({
-        key: `${daacId}/${submissionId}/${fileCategory}/${user}/${fileName}`,
+        key: `${submissionId}/${fileCategory}/${user}/${fileName}`,
         checksumValue,
         fileType,
         fileCategory
@@ -202,7 +202,7 @@ async function listFilesMethod(event, user) {
     || userDaacIds.includes(daacId)
   ) {
     const s3Client = new S3Client({ region });
-    const command = new ListObjectsCommand({ Bucket: ingestBucket, Prefix: `${daacId}/${submissionId}` });
+    const command = new ListObjectsCommand({ Bucket: ingestBucket, Prefix: `${submissionId}` });
 
     try {
       rawResponse = await s3Client.send(command);

--- a/src/nodejs/lambda-handlers/notification-consumer/templates.js
+++ b/src/nodejs/lambda-handlers/notification-consumer/templates.js
@@ -70,14 +70,12 @@ const getEmailTemplate = async (eventMessage, message) => {
   if (eventMessage.event_type !== 'direct_message') {
     const workflowName = db.workflow.getLongName({ id: eventMessage.workflow_id });
     const formData = (await db.submission.getFormData({ id: eventMessage.submission_id })).data;
-    const daac = await db.submission.getSubmissionDaac({ id: eventMessage.submission_id });
 
     emailPayload = {
       submission_id: eventMessage.submission_id,
       workflow_name: (await workflowName).long_name,
       conversation_last_message: message.text,
       event_type: eventMessage.event_type,
-      daac_name: daac.short_name,
       user_id: eventMessage.user_id,
       submitted_by_name: eventMessage.submitted_by_name
     };

--- a/src/nodejs/lambda-handlers/test/handlers/file-upload.test.js
+++ b/src/nodejs/lambda-handlers/test/handlers/file-upload.test.js
@@ -41,7 +41,7 @@ describe('file-upload', () => {
     createPresignedPost.mockImplementationOnce((client, functPayload) => {
       expect(functPayload).toEqual({
         Bucket: 'TEST_BUCKET',
-        Key: 'daac_id/some_id/sample/user_id/test.txt',
+        Key: 'some_id/sample/user_id/test.txt',
         Conditions: [
           { 'x-amz-meta-checksumalgorithm': 'SHA256' },
           { 'x-amz-meta-checksumvalue': '1234567890' },

--- a/src/nodejs/lambda-handlers/test/handlers/notification-consumer.test.js
+++ b/src/nodejs/lambda-handlers/test/handlers/notification-consumer.test.js
@@ -66,7 +66,6 @@ describe('notification-consumer', () => {
         conversation_last_message: 'Data Accession Request Form review completed; please click on the green button on the far right of your request’s row to complete the next action, if applicable.',
         event_type: 'review_approved',
         submission_name: 'test product',
-        daac_name: 'test daac',
         user_id: '1b10a09d-d342-4eee-a9eb-c99acd2dde17'
       });
       return {};

--- a/src/nodejs/lambda-layers/message-util/src/templates/default-step-promotion.js
+++ b/src/nodejs/lambda-layers/message-util/src/templates/default-step-promotion.js
@@ -18,7 +18,7 @@ const getDefaultStepPromotion = (params, envUrl) => {
                 <td colspan="2" style="padding:20px;">
                     <h1>Hello ${user.name},</h1><br>
                     <br>
-                    <p>The following request to the ${eventMessage.daac_name} in Earthdata Pub has a change in status:</p>
+                    <p>The following request in Earthdata Pub has a change in status:</p>
                     <h2>Request:</h2>
                     <p><a style="text-align: left;" href="${envUrl}/dashboard/requests/id/${eventMessage.submission_id}" aria-label="View the request">${eventMessage.submission_name} (${eventMessage.submission_id})</a><br></p>
                     <h2>New Status:</h2>

--- a/src/nodejs/lambda-layers/message-util/src/templates/new-submission-daac.js
+++ b/src/nodejs/lambda-layers/message-util/src/templates/new-submission-daac.js
@@ -1,5 +1,5 @@
 const getNewSubmissionDAACTemplate = (params, envUrl) => {
-  const newSubmissionDAACText = `Hello ${params.user.name},\n\nA request has been submitted to the ${params.eventMessage.daac_name} in Earthdata Pub. The submission has received the following temporary name:\n\n${params.eventMessage.submission_name}\n\nThank you for using Earthdata Pub.`;
+  const newSubmissionDAACText = `Hello ${params.user.name},\n\nA request has been submitted to Earthdata Pub. The submission has received the following temporary name:\n\n${params.eventMessage.submission_name}\n\nThank you for using Earthdata Pub.`;
   const newSubmissionDAACHTML = `
     <html>
     <body>
@@ -17,7 +17,7 @@ const getNewSubmissionDAACTemplate = (params, envUrl) => {
                 <td colspan="2" style="padding:20px;">
                     <h1>Hello ${params.user.name},</h1><br>
                     <br>
-                    <p>A request has been submitted to the ${params.eventMessage.daac_name} in Earthdata Pub. The submission has received the following temporary name:</p>
+                    <p>A request has been submitted to Earthdata Pub. The submission has received the following temporary name:</p>
                     <p><a style="text-align: left;" href="${envUrl}/dashboard/requests/id/${params.eventMessage.submission_id}" aria-label="View the request">
                     ${params.eventMessage.submission_name}</a></p>
                     <p>Thank you for using Earthdata Pub.</p>

--- a/src/nodejs/lambda-layers/message-util/src/templates/new-submission.js
+++ b/src/nodejs/lambda-layers/message-util/src/templates/new-submission.js
@@ -1,5 +1,5 @@
 const getNewSubmissionTemplate = (params, envUrl) => {
-  const newSubmissionText = `Hello ${params.user.name},\n\nThank you for creating a request to the ${params.eventMessage.daac_name} in Earthdata Pub. On your personal dashboard (${envUrl}/dashboard), your submission has received the following temporary name:\n\n${params.eventMessage.submission_name}\n\nPlease click on the green button on the far right of your submission's row to complete the appropriate form, which will gather information to continue your submission.\n\nThank you for using Earthdata Pub.`;
+  const newSubmissionText = `Hello ${params.user.name},\n\nThank you for creating a request in Earthdata Pub. On your personal dashboard (${envUrl}/dashboard), your submission has received the following temporary name:\n\n${params.eventMessage.submission_name}\n\nPlease click on the green button on the far right of your submission's row to complete the appropriate form, which will gather information to continue your submission.\n\nThank you for using Earthdata Pub.`;
   const newSubmissionHTML = `
     <html>
     <body>
@@ -17,7 +17,7 @@ const getNewSubmissionTemplate = (params, envUrl) => {
                 <td colspan="2" style="padding:20px;">
                     <h1>Hello ${params.user.name},</h1><br>
                     <br>
-                    <p>Thank you for creating a request to the ${params.eventMessage.daac_name} in Earthdata Pub.  On your personal dashboard (${envUrl}/dashboard), your submission has received the following temporary name:</p>
+                    <p>Thank you for creating a request in Earthdata Pub.  On your personal dashboard (${envUrl}/dashboard), your submission has received the following temporary name:</p>
                     <p><a style="text-align: left;" href="${envUrl}/dashboard/requests/id/${params.eventMessage.submission_id}" aria-label="View the request">
                     ${params.eventMessage.submission_name}</a></p>
                     <p>Please click on the green button on the far right of your submission’s row to complete the appropriate form, which will gather information to continue your submission.</p>


### PR DESCRIPTION
… daac

## Description

Do to the changes caused by the re-route feature, a submission will not always have a daac id associated with it. This has caused issues in various places that rely on it's existence to perform as expected. Three specific issues were identified as part of this work and each were checked/updated accordingly.

- File Uploads: references to the daac as part of file upload have been removed
- submissionFindById: tested as part of this ticket and believe was fixed as part of https://github.com/eosdis-nasa/earthdata-pub-api/pull/217
- Email templates: references to the daac as part of the email templates have been removed

## Linked JIRA Task or Github Issue

JIRA Task: https://bugs.earthdata.nasa.gov/browse/EDPUB-1508

## Types of changes

What types of changes does your code introduce to Earthdata Pub (EDPub)?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [ ] Other (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CHANGELOG.md)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Validation Steps

_This will help us get a jump start on validating your PR by describing the steps to replicate
and validate the expected behavior. (For an example of good validation instructions, check out [Bryan's Bouncy Ball PR.](https://github.com/sparkbox/bouncy-ball/pull/56#issue-192153701))_

### Testing getPostUrlMethod
1. Make sure all merge request checks have passed (CI/CD)
2. Pull related branches locally
3. Create a new submission as a DP with an unknown DAAC
4. Authenticate into swagger with the admin role
5. Run the /data/upload/getPostURL method with the submission ID from step 1
6. verify that the key value is in the form {submissionId}/{category}/{user}/{file_name}
7. Authenticate into swagger with a DAAC Staff role
8.  Re-run query
9. Verify that the return value is a submission not found error
10. Update the submission daac to be that of the DAAC Staff user
11. Re-run the query
12.  Verify that the key returned is the same format as above

### Testing  Email Templates and Download Links
1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches to SIT.
3. Create a new submission
4. Verify that the email received does not include the DAAC Name
5. Upload a file in the documentation/sample file area(s)
6. Move the submission to the DAR Approval Step
7. Verify that the file download link works as expected


## Further comments

In the validation of download links it was noted that the files are not being split appropriately. A note has been added for a follow on task to fix this issue.
