### PR TITLE
Hotfix: Allow dar form project name to populate name field in submission

### DIFF
--- a/src/nodejs/lambda-handlers/submission.js
+++ b/src/nodejs/lambda-handlers/submission.js
@@ -160,7 +160,8 @@ async function metadataMethod(event, user) {
 async function saveMethod(event) {
   const { form_id: formId, daac_id: daacId, data } = event;
   const { id } = event;
-  const { data_product_name_value: dataProduct, data_producer_info_name: dataProducer } = data;
+  const { data_producer_info_name: dataProducer } = data;
+  const dataProduct = data.data_product_name_value || data.dar_form_project_name_info;
   await db.submission.updateFormData({ id, form_id: formId, data: JSON.stringify(data) });
   await db.submission.updateSubmissionData({ id, dataProduct, dataProducer });
   await db.submission.updateMetadata({ id, metadata: JSON.stringify(await mapEDPubToUmmc(data)) });


### PR DESCRIPTION
## Description

Updated code so that DAR form project name populates submission name field

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [ ] Other (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CHANGELOG.md)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Validation Steps

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Create a new accession request.
4. Populate the project name field and save the form as a draft.
5. Return to the request overview page.
6. Validate that the project name field populates the data product name column.
