### PR TITLE
Adding removal of submission secrets on submission close or withdrawl

### DIFF
--- a/src/nodejs/lambda-handlers/submission.js
+++ b/src/nodejs/lambda-handlers/submission.js
@@ -264,6 +264,7 @@ async function withdrawMethod(event, user) {
   if (user.id?.includes('service-authorizer') || approvedUserPrivileges.some((privilege) => user.user_privileges.includes(privilege))) {
     const submission = await db.submission.withdrawSubmission({ id });
     const submissionMetrics = await db.metrics.getSubmissions({ submissionId: id });
+    await db.service.deleteSubmissionSecrets({ submissionId: id });
     await msg.sendEvent({
       event_type: 'workflow_completed',
       submission_id: id,

--- a/src/nodejs/lambda-handlers/test/handlers/submission.test.js
+++ b/src/nodejs/lambda-handlers/test/handlers/submission.test.js
@@ -39,6 +39,7 @@ db.metrics = jest.fn();
 db.metrics.getSubmissions = jest.fn();
 db.service = jest.fn();
 db.service.deleteSecret = jest.fn();
+db.service.deleteSubmissionSecrets = jest.fn();
 
 msg.sendEvent = jest.fn();
 

--- a/src/nodejs/lambda-handlers/workflow-consumer.js
+++ b/src/nodejs/lambda-handlers/workflow-consumer.js
@@ -123,6 +123,7 @@ async function uploadMethod(status) {
 }
 
 async function closeMethod(status) {
+  await db.service.deleteSubmissionSecrets({ submissionId: status.id });
   const submissionMetrics = await db.metrics.getSubmissions({
     submissionId: status.id
   });

--- a/src/nodejs/lambda-layers/database-util/src/query/parsers.js
+++ b/src/nodejs/lambda-layers/database-util/src/query/parsers.js
@@ -63,6 +63,7 @@ module.exports.inputFindAll = many;
 module.exports.findSecret = one;
 module.exports.createSecret = one;
 module.exports.deleteSecret = one;
+module.exports.deleteSubmissionSecrets = one;
 module.exports.deleteInput = one;
 module.exports.updateWorkflowMetaData = one;
 module.exports.setStep = one;

--- a/src/nodejs/lambda-layers/database-util/src/query/service.js
+++ b/src/nodejs/lambda-layers/database-util/src/query/service.js
@@ -6,6 +6,7 @@ const findByName = () => `${findAll()} WHERE service.short_name = {{short_name}}
 const createSecret = () => `INSERT INTO service_secret(id, secret, submission_id) VALUES ({{id}}, {{secret}}, {{submission_id}})`;
 const findSecret = () => `SELECT * FROM service_secret WHERE service_secret.id = {{id}} AND service_secret.submission_id = {{submissionId}}`;
 const deleteSecret = () => `DELETE FROM service_secret WHERE service_secret.id = {{serviceId}} AND service_secret.submission_id = {{submissionId}}`;
+const deleteSubmissionSecrets = () => `DELETE FROM service_secret WHERE service_secret.submission_id = {{submissionId}}`;
 
 module.exports.findAll = findAll;
 module.exports.findById = findById;
@@ -13,3 +14,4 @@ module.exports.findByName = findByName;
 module.exports.createSecret = createSecret;
 module.exports.findSecret = findSecret;
 module.exports.deleteSecret = deleteSecret;
+module.exports.deleteSubmissionSecrets = deleteSubmissionSecrets;


### PR DESCRIPTION
## Description

When a submission is closed or withdrawn all associated secrets should be removed from use. This PR adds a database function to remove the secrets by the submission id and adds calls to it in the withdraw and close functions.

## Linked JIRA Task or Github Issue

JIRA Task: https://bugs.earthdata.nasa.gov/browse/EDPUB-1555

## Types of changes

What types of changes does your code introduce to Earthdata Pub (EDPub)?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [ ] Other (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CHANGELOG.md)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Validation Steps

_This will help us get a jump start on validating your PR by describing the steps to replicate
and validate the expected behavior. (For an example of good validation instructions, check out [Bryan's Bouncy Ball PR.](https://github.com/sparkbox/bouncy-ball/pull/56#issue-192153701))_

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Create a new request
4. On the request overview page, Reassign the workflow to the `ORNL Test Workflow`
5. Verify that a service secret entry exists for the request in your db tables
6. Withdraw the submission
7. Verify that the service secret entry has been deleted
8. Repeat steps 3-5.
9. Move the submission to the `Email DAAC Staff` step
10. Go to the action page and click `Continue`
11. Verify that the service secret entry has been deleted

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

Important to note that the 'Restore Request' option on a withdrawn submission will not re-populate the service secret. It will require someone to manually trigger it's re-creation (Easiest way would be by setting the submission one step before the service trigger, or if it's the first step - reassigning the workflow to itself.)