### PR TITLE
Hotfix: Resolve terraform deployment issue

### DIFF
--- a/terraform/apigateway/main.tf
+++ b/terraform/apigateway/main.tf
@@ -47,5 +47,10 @@ data "local_file" "edpub_api_policy" {
 
 resource "aws_api_gateway_deployment" "earthdatapub_api_gateway_deployment" {
   rest_api_id = aws_api_gateway_rest_api.EarthdataPub.id
-  stage_name  = var.stage
+}
+
+resource "aws_api_gateway_stage" "earthdatapub_api_gateway_stage" {
+  deployment_id = aws_api_gateway_deployment.earthdatapub_api_gateway_deployment.id
+  rest_api_id = aws_api_gateway_rest_api.EarthdataPub.id
+  stage_name    = var.stage
 }


### PR DESCRIPTION
Create dedicated aws api gateway stage resource to avoid terraform supported field error

## Description

Chelsey found an issue in deploying where terraform no longer allows the use of the stage_name attribute in favor of the dedicated resource. This also requires importing the existing stage to the environment's terraform state before `terraform apply`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [ ] Other (if none of the other choices apply)

## Validation Steps

1. Make sure all merge request checks have passed (CI/CD).
2. Deploy the feature branch in bamboo.
3. Validate that you don't receive an error like:
```
Error: Unsupported argument

  on apigateway/main.tf line 50, in resource "aws_api_gateway_deployment" "earthdatapub_api_gateway_deployment":
  50:   stage_name  = var.stage

An argument named "stage_name" is not expected here.
```