### PR TITLE
Hotfix: Update submissionId extraction location

### DIFF
--- a/src/nodejs/lambda-handlers/file-upload.js
+++ b/src/nodejs/lambda-handlers/file-upload.js
@@ -270,7 +270,7 @@ async function getDownloadUrlMethod(event, user) {
     region
   });
 
-  const submissionId = key.split('/')[1];
+  const submissionId = key.split('/')[0];
   const userInfo = await db.user.findById({ id: user });
   const groupIds = userInfo.user_groups.map((group) => group.id);
   const userDaacs = groupIds.length > 0 ? await db.daac.getIds({ group_ids: groupIds }) : [];


### PR DESCRIPTION
## Description

GES DISC reported an issue with downloading files which upon further investigation is the result of the file location changing due to the reroute feature updates. This changes aligns the download urls with the file location.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [ ] Other (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CHANGELOG.md)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Validation Steps

1. Make sure all merge request checks have passed (CI/CD).
2. Push the changes to SIT.
3. Validate that you are able to download a file listed in a request.