### PR TITLE
EDPUB-653: Metadata mapper updates

### DIFF
--- a/src/nodejs/lambda-handlers/submission/metadata-mapper.js
+++ b/src/nodejs/lambda-handlers/submission/metadata-mapper.js
@@ -208,7 +208,15 @@ const mapEDPubToUmmc = async (formData) => {
 
   // Strip nulls and empty objects
   tmpArr = tmpArr.filter((value) => Object.keys(stripNullsFromObject(value)).length !== 0);
-  spatialExtent.SpatialExtent.HorizontalSpatialDomain.Geometry.BoundingRectangles = spatialExtent.SpatialExtent.HorizontalSpatialDomain.Geometry.BoundingRectangles.concat(tmpArr);
+
+  if (tmpArr.length > 0) {
+    // If coordinate array not empty, populate metadata object
+    spatialExtent.SpatialExtent.HorizontalSpatialDomain.Geometry.BoundingRectangles = spatialExtent.SpatialExtent.HorizontalSpatialDomain.Geometry.BoundingRectangles.concat(tmpArr);
+  } else {
+    // Otherwise, remove empty metadata field
+    for (let element in spatialExtent) delete spatialExtent[element];
+  }
+
   // Delete spatial extent information
   ['west', 'north', 'east', 'south'].forEach((direction) => {
     [1, 2, 3].forEach((directionSet) => {
@@ -630,14 +638,6 @@ const mapEDPubToUmmc = async (formData) => {
     ]
   };
 
-  const metadataSpecification = {
-    MetadataSpecification: {
-      URL: 'https://cdn.earthdata.nasa.gov/umm/collection/v1.17.0',
-      Name: 'UMM-C',
-      Version: '1.17.0'
-    }
-  };
-
   // Added to capture DAAC specific questions
   Object.keys(formData).forEach((extra) => {
     additionalAttributes.push({
@@ -662,8 +662,7 @@ const mapEDPubToUmmc = async (formData) => {
     ...(temporalExtent || {}),
     ...(spatialExtent || {}),
     ...(additionalAttributes ? { AdditionalAttributes: additionalAttributes } : {}),
-    ...(metadataDates || {}),
-    ...(metadataSpecification || {})
+    ...(metadataDates || {})
   }));
 };
 

--- a/src/nodejs/lambda-handlers/submission/metadata-mapper.js
+++ b/src/nodejs/lambda-handlers/submission/metadata-mapper.js
@@ -214,7 +214,7 @@ const mapEDPubToUmmc = async (formData) => {
     spatialExtent.SpatialExtent.HorizontalSpatialDomain.Geometry.BoundingRectangles = spatialExtent.SpatialExtent.HorizontalSpatialDomain.Geometry.BoundingRectangles.concat(tmpArr);
   } else {
     // Otherwise, remove empty metadata field
-    for (let element in spatialExtent) delete spatialExtent[element];
+    Object.keys(spatialExtent).forEach((key) => { delete spatialExtent[key]; });
   }
 
   // Delete spatial extent information


### PR DESCRIPTION
## Description

MMT's recent re-addition of collection draft upload updated some of its schema restrictions. The below updates were made to EDPub's metadata mapper to accommodate those updates.

## Linked JIRA Task or Github Issue

JIRA Task: https://bugs.earthdata.nasa.gov/browse/EDPUB-1653

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [ ] Other (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CHANGELOG.md)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Validation Steps

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Test exporting metadata from EDPub.
4. Confirm that you no longer have a metadata specification block.
5. Confirm that the spatial extent block is only populated if it contains coordinates.