### PR TITLE
updating endpoint token variables to be secrets

### DIFF
--- a/terraform/modules.tf
+++ b/terraform/modules.tf
@@ -32,9 +32,9 @@ module "aws_secrets" {
   ses_secret_sender_arn = var.ses_secret_sender_arn
   ses_configuration_set_name = var.ses_configuration_set_name
   ornl_endpoint_url = var.ornl_endpoint_url
-  ornl_endpoint_access_token = var.ornl_endpoint_access_token
+  ornl_endpoint_access_token = var.ornl_endpoint_access_token_secret
   gesdisc_endpoint_url = var.gesdisc_endpoint_url
-  gesdisc_endpoint_access_token = var.gesdisc_endpoint_access_token
+  gesdisc_endpoint_access_token = var.gesdisc_endpoint_access_token_secret
   ornl_service_authorization = var.ornl_service_authorization_secret
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -114,7 +114,7 @@ variable "ornl_endpoint_url" {
   type = string
 }
 
-variable "ornl_endpoint_access_token" {
+variable "ornl_endpoint_access_token_secret" {
   type = string
 }
 
@@ -122,7 +122,7 @@ variable "gesdisc_endpoint_url"{
   type = string
 }
 
-variable "gesdisc_endpoint_access_token"{
+variable "gesdisc_endpoint_access_token_secret"{
   type = string
 }
 


### PR DESCRIPTION
## Description

Updates the Bamboo Variables for the GESDISC & ORNL endpoints to be secrets

## Linked JIRA Task or Github Issue

JIRA Task: [EDPUB-1614](https://bugs.earthdata.nasa.gov/browse/EDPUB-1614)

## Types of changes

What types of changes does your code introduce to Earthdata Pub (EDPub)?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [x] Other (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CHANGELOG.md)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Validation Steps

_This will help us get a jump start on validating your PR by describing the steps to replicate
and validate the expected behavior. (For an example of good validation instructions, check out [Bryan's Bouncy Ball PR.](https://github.com/sparkbox/bouncy-ball/pull/56#issue-192153701))_

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches to SIT.
3. Navigate to the Secrets Manager
4. Verify that the access tokens within the `gesdisc_endpoint` and `ornl_endpoint` secrets match the expected values.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...