### PR TITLE
Adding GROUP_UPLOAD privilege to DAAC Data Manager role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updated the language for Open Data Policy questions in DAR and DER
 - Removing terraform references to edpub_metrics_s3_bucket
 - Removing unused database tables and references to them
+- Added Group_Upload privilege to DAAC Data Manager role
 
 ## 1.1.0
 

--- a/src/postgres/7-seed.sql
+++ b/src/postgres/7-seed.sql
@@ -402,6 +402,7 @@ INSERT INTO edprole_privilege VALUES ('2aa89c57-85f1-4611-812d-b6760bb6295c', 'N
 INSERT INTO edprole_privilege VALUES ('2aa89c57-85f1-4611-812d-b6760bb6295c', 'METRICS_READ');
 INSERT INTO edprole_privilege VALUES ('2aa89c57-85f1-4611-812d-b6760bb6295c', 'NOTE_ADDUSER');
 INSERT INTO edprole_privilege VALUES ('2aa89c57-85f1-4611-812d-b6760bb6295c', 'NOTE_REMOVEUSER');
+INSERT INTO edprole_privilege VALUES ('2aa89c57-85f1-4611-812d-b6760bb6295c', 'GROUP_UPLOAD');
 
 --RolePrivilege(edprole_id, privilege) Observer
 INSERT INTO edprole_privilege VALUES ('4be6ca4d-6362-478b-8478-487a668314b1', 'REQUEST_DAACREAD');

--- a/src/postgres/9-updates.sql
+++ b/src/postgres/9-updates.sql
@@ -230,3 +230,6 @@ WHERE question_id = 'a3701d37-77cf-4ccc-8068-c6860a7a8929' AND control_id = 'spa
 -- EDPUB-1749: Fix email validation in DAR/DER
 UPDATE input SET type = 'email' WHERE control_id='dar_form_principal_investigator_email'
 UPDATE input SET type = 'email' WHERE control_id='dar_form_data_accession_poc_email'
+
+-- EDPUB-1765: Add Groups page for DAAC Managers
+INSERT INTO edprole_privilege VALUES ('2aa89c57-85f1-4611-812d-b6760bb6295c', 'GROUP_UPLOAD');


### PR DESCRIPTION
## Description

Adds the GROUP_UPLOAD privilege to the DAAC Data Manager role. This addition is responsible for the Groups menu item being available to Data Managers

## Linked JIRA Task or Github Issue

JIRA Task: [EDPUB-1765](https://bugs.earthdata.nasa.gov/browse/EDPUB-1765)

## Types of changes

What types of changes does your code introduce to Earthdata Pub (EDPub)?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [X] Other (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CONTRIBUTING.md)
- [X] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CHANGELOG.md)
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Validation Steps

_This will help us get a jump start on validating your PR by describing the steps to replicate
and validate the expected behavior. (For an example of good validation instructions, check out [Bryan's Bouncy Ball PR.](https://github.com/sparkbox/bouncy-ball/pull/56#issue-192153701))_

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Create a DAAC Manager account
4. Log in to the dashboard as a DAAC Manager
5. Verify that the Groups option is visible in the header for that account
6. Click on Groups in the header
7. Verify that the groups page is accessible

## Further comments

This PR assumes the intention is for the Data Manager to have Upload privileges as well as viewership of the group page. As I didn't see a reason why we wouldn't want the Data Manager to be able to upload I went ahead and took this route. If that is not the desired effect we could add a GROUP_READ option that would only allow visibility to the Group pages and not upload functionality. 